### PR TITLE
Add lint:js:fix script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "jest --coverage=true",
     "prewatch": "gulp build",
     "watch": "gulp",
-    "lint:js": "eslint -c ./linters/.eslintrc.js app.js middleware/**/*.js lib/**/*.js app/*.js"
+    "lint:js": "eslint -c ./linters/.eslintrc.js app.js middleware/**/*.js lib/**/*.js app/*.js",
+    "lint:js:fix": "eslint -c ./linters/.eslintrc.js app.js middleware/**/*.js lib/**/*.js app/*.js --fix"
   },
   "author": "https://github.com/nhsuk/",
   "license": "MIT",


### PR DESCRIPTION
This lets you do `npm run lint:js:fix` to more easily run the JavaScript code style checks in auto-fix mode.