### PR TITLE
Switch to using the header macro

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -1,7 +1,7 @@
 {% extends 'layout.html' %}
 
 {% block header %}
-  {{ header({}) }}
+  {{ super() }}
   {{ hero({
     "heading": "NHS.UK prototype kit",
     "text": "Rapidly create HTML prototypes of NHS.UK services."

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -12,21 +12,13 @@
 {% endblock %}
 
 {% block header %}
-  <header class="nhsuk-header" role="banner">
-    <div class="nhsuk-header__container">
-      <div class="nhsuk-header__logo nhsuk-header__logo--only">
-        <a class="nhsuk-header__link nhsuk-header__link--service" href="/" aria-label="NHS.UK prototype kit home">
-          <svg class="nhsuk-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 16" height="40" width="100">
-            <path class="nhsuk-logo__background" fill="#005eb8" d="M0 0h40v16H0z"></path>
-            <path class="nhsuk-logo__text" fill="#fff" d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"></path>
-          </svg>
-          <span class="nhsuk-header__service-name">
-          {{serviceName}}
-          </span>
-        </a>
-      </div>
-    </div>
-  </header>
+  {{ header({
+    homeHref: "/",
+    ariaLabel: "NHS Prototype Kit homepage",
+    service: {
+      name: serviceName
+    }
+  }) }}
 {% endblock %}
 
 {% block footer %}


### PR DESCRIPTION
This is more future-proof, especially with upcoming changes to the header.

Also fixes a bug where the service name wasn't appearing in the header on the homepage - not sure if that was deliberate or not but feels wrong?

Otherwise there’s no changes.

| Before | After |
| -------|-------|
| <img width="1210" alt="Prototype Kit website with just the NHS logo in the header" src="https://github.com/user-attachments/assets/414a2e8b-8302-474f-adc0-8c83d99e0d9a"> | <img width="1210" alt="Prototype Kit website with 'Prototype Kit' next to NHS logo in the header" src="https://github.com/user-attachments/assets/8fa26375-760d-4274-9a43-202102903b0c"> |

