### PR TITLE
Fix link

### DIFF
--- a/app/views/how-tos/switching-from-govuk-prototype-kit.html
+++ b/app/views/how-tos/switching-from-govuk-prototype-kit.html
@@ -31,7 +31,7 @@ When you are installing and running your prototype:
   type: "tick",
   items: [
   {
-    item: '<a href="/install/download-zip">download the kit using the zip file or Github</a>'
+    item: '<a href="/install/advanced">download the kit using the zip file or Github</a>'
   },
     {
       item: 'check when you install your prototype that you are using the right version of Node.js - you may need to install and use a different version. If you need to make prototypes for both NHS.UK and GOV.UK you can switch versions of node with a <a href="https://github.com/nvm-sh/nvm">node version manager</a>'


### PR DESCRIPTION
We don't have a standalone download page now, so this link should probably go to the advanced install guide which has the link to download or to clone from GitHub.