### PR TITLE
Install guide: add signposting about chosen operation system and breadcrumb to guide start

### DIFF
--- a/app/views/how-tos/switching-from-govuk-prototype-kit.html
+++ b/app/views/how-tos/switching-from-govuk-prototype-kit.html
@@ -1,119 +1,120 @@
-{% extends 'layout.html' %} {% block pageTitle %} Switching from the GOV.UK
-Prototype Kit - NHS.UK prototype kit {% endblock %} {% block beforeContent %} {%
-include "how-tos/includes/breadcrumb.html" %} {% endblock %} {% block content %}
-<div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-two-thirds">
-    <h1 class="nhsuk-heading-xl">Switching from the GOV.UK prototype kit</h1>
+{% extends 'layout.html' %}
 
-    <p>
-      If you have learned how to use the
-      <a href="https://prototype-kit.service.gov.uk/docs/"
-        >GOV.UK Prototype Kit</a
-      >, you will be able to use the NHS.UK prototype kit. This is because the
-      two prototype kits are built in the same way. However, you must do some
-      things differently.
+{% block pageTitle %}
+  Switching from the GOV.UK Prototype Kit - NHS.UK prototype kit
+{% endblock %}
+
+{% block beforeContent %}
+  {% include "how-tos/includes/breadcrumb.html" %}
+{% endblock %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+
+    <div class="nhsuk-grid-column-two-thirds">
+
+      <h1 class="nhsuk-heading-xl">
+        Switching from the GOV.UK prototype kit
+      </h1>
+
+
+<p>
+      If you have learned how to use the <a href="https://prototype-kit.service.gov.uk/docs/">GOV.UK Prototype Kit</a>, you will be able to use the NHS.UK prototype kit. This is because the two prototype kits are built in the same way. However, you must do some things differently.
     </p>
-    <h2 class="nhsuk-heading-m">
-      Installing and running the NHS.UK prototype kit
-    </h2>
+<h2 class="nhsuk-heading-m">Installing and running the NHS.UK prototype kit</h2>
 
-    <p>When you are installing and running your prototype:</p>
+<p>
+When you are installing and running your prototype:
 
-    {{ list({ title: "Do", type: "tick", items: [ { item: '<a
-      href="/install/advanced"
-      >download the kit using the zip file or Github</a
-    >' }, { item: 'check when you install your prototype that you are using the
-    right version of Node.js - you may need to install and use a different
-    version. If you need to make prototypes for both NHS.UK and GOV.UK you can
-    switch versions of node with a
-    <a href="https://github.com/nvm-sh/nvm">node version manager</a>' }, { item:
-    'start your local server by entering in the terminal:
-    <pre
-      class="app-pre"
-    ><code class="language-markup">npm run watch</code></pre>
-    ' } ] }) }} {{ list({ title: "Don’t", type: "cross", items: [ { item: 'try
-    to create a prototype by running a command in the terminal - you must
-    download it' }, { item: 'start your local server the same way as in the
-    GOV.UK Prototype Kit as it will not work' } ] }) }}
+{{ list({
+  title: "Do",
+  type: "tick",
+  items: [
+  {
+    item: '<a href="/install/advanced">download the kit using the zip file or Github</a>'
+  },
+    {
+      item: 'check when you install your prototype that you are using the right version of Node.js - you may need to install and use a different version. If you need to make prototypes for both NHS.UK and GOV.UK you can switch versions of node with a <a href="https://github.com/nvm-sh/nvm">node version manager</a>'
+    },
+    {
+      item: 'start your local server by entering in the terminal: <pre class="app-pre"><code class="language-markup">npm run watch</code></pre> '
+    }
+  ]
+}) }}
 
-    <h2>Making pages</h2>
+{{ list({
+  title: "Don’t",
+  type: "cross",
+  items: [
+  {
+    item: 'try to create a prototype by running a command in the terminal - you must download it'
+  },
+    {
+      item: 'start your local server the same way as in the GOV.UK Prototype Kit as it will not work'
+    }
+  ]
+}) }}
 
-    <p>When you are making pages:</p>
 
-    {{ list({ title: "Do", type: "tick", items: [ { item: 'use the NHS.UK design
-    system for
-    <a href="https://service-manual.nhs.uk/design-system/styles">styles</a>,
-    <a href="https://service-manual.nhs.uk/design-system/components"
-      >components</a
-    >
-    and
-    <a href="https://service-manual.nhs.uk/design-system/patterns">patterns</a>
-    - you can also copy
-    <a href="/page-templates">template pages in the NHS prototype kit</a>' }, {
-    item: 'use
-    <a href="https://service-manual.nhs.uk/design-system"
-      >NHS.UK macro naming conventions</a
-    >
-    which do not have a prefix, for example
-    <code class="language-markup">{{ radios }}</code> instead of
-    <code class="language-markup">{{ govukRadios }}</code>' }, { item: 'use
-    <a href="https://service-manual.nhs.uk/design-system/styles/typography"
-      >NHS.UK typography classes</a
-    >
-    on headings and other text, for example
-    <pre
-      class="app-pre"
-    ><code class="language-markup">' + '<p class="nhsuk-body">nhsuk-body</p>' | escape  + '</code></pre>
-    ' }, { item: 'know that the NHS.UK prototype kit does not have some
-    functionality that is in the GOV.UK one, for example the interface to create
-    pages from templates' }, { item: 'know that plugins designed for the GOV.UK
-    Prototype Kit may not work or may need to be installed differently - for
-    example, if you want to use the
-    <a href="https://x-govuk.github.io/govuk-prototype-filters/get-started/"
-      >GOV.UK Prototype Kit Filters plugin</a
-    >
-    you must use instructions for earlier versions of the kit and make changes
-    in <code class="language-markup">filters.js</code>.' } ] }) }} {{ list({
-    title: "Don’t", type: "cross", items: [ { item: 'copy pages from the GOV.UK
-    design system or GOV.UK prototype kit and expect them to work - you may need
-    to copy over extra code like CSS to make them work properly' }, { item: 'use
-    GOV.UK macro naming conventions as they will not work' }, { item: 'use
-    GOV.UK typography classes as they will not work' } ] }) }}
-    <h2 class="nhsuk-heading-m">Using routing and session data</h2>
 
-    <p>
-      You can define routes to do branching logic or other custom behaviour in
-      the same way as the GOV.UK Prototype Kit.
-    </p>
+<h2>Making pages</h2>
 
-    <p>
-      You can also add default session data in
-      <code class="language-markup">data/session-data-defaults.js</code>
-    </p>
+<p>
+  When you are making pages:
+</p>  
 
-    <p>
-      Unlike the GOV.UK Prototype Kit, if you save any changes the the routes
-      file, the app will restart and any session data will revert to the
-      default.
-    </p>
+{{ list({
+  title: "Do",
+  type: "tick",
+  items: [
+    {
+      item: 'use the NHS.UK design system for <a href="https://service-manual.nhs.uk/design-system/styles">styles</a>, <a href="https://service-manual.nhs.uk/design-system/components">components</a> and <a href="https://service-manual.nhs.uk/design-system/patterns">patterns</a> - you can also copy <a href="/page-templates">template pages in the NHS prototype kit</a>'
+    },
+    {
+      item: 'use <a href="https://service-manual.nhs.uk/design-system">NHS.UK macro naming conventions</a> which do not have a prefix, for example <code class="language-markup">{{ radios }}</code> instead of <code class="language-markup">{{ govukRadios }}</code>'
+    },
+    {
+      item: 'use <a href="https://service-manual.nhs.uk/design-system/styles/typography">NHS.UK typography classes</a> on headings and other text, for example <pre class="app-pre"><code class="language-markup">' + '<p class="nhsuk-body">nhsuk-body</p>' | escape  + '</code></pre>'
+    },
+    {
+      item: 'know that the NHS.UK prototype kit does not have some functionality that is in the GOV.UK one, for example the interface to create pages from templates'
+   },
+   {
+      item: 'know that plugins designed for the GOV.UK Prototype Kit may not work or may need to be installed differently - for example, if you want to use the <a href="https://x-govuk.github.io/govuk-prototype-filters/get-started/">GOV.UK Prototype Kit Filters plugin</a> you must use instructions for earlier versions of the kit and make changes in <code class="language-markup">filters.js</code>.'
+    }
+  ]
+}) }}
 
-    <h2>Help and support</h2>
+{{ list({
+  title: "Don’t",
+  type: "cross",
+  items: [
+    {
+      item: 'copy pages from the GOV.UK design system or GOV.UK prototype kit and expect them to work - you may need to copy over extra code like CSS to make them work properly'
+    },
+    {
+      item: 'use GOV.UK macro naming conventions as they will not work'
+    },
+    {
+      item: 'use GOV.UK typography classes as they will not work'
+    }
+  ]
+}) }}
+<h2 class="nhsuk-heading-m">Using routing and session data</h2>
 
-    <p>
-      If you have any problems, ask a developer on your team (if you have one),
-      <a
-        href="mailto:england.service-manual@nhs.net?subject=NHS.UK prototype kit - Updating the kit"
-        >email us</a
-      >
-      or get in touch on the
-      <a
-        href="https://nhs-service-manual.slack.com/messages/CFYL2GDGW"
-        rel="nofollow"
-        >NHS digital service manual #prototype-kit Slack channel</a
-      >.
-    </p>
+<p>You can define routes to do branching logic or other custom behaviour in the same way as the GOV.UK Prototype Kit.</p>
 
-    {% include "how-tos/includes/back-button.html" %}
+<p>You can also add default session data in <code class="language-markup">data/session-data-defaults.js</code></p>
+
+<p>Unlike the GOV.UK Prototype Kit, if you save any changes the the routes file, the app will restart and any session data will revert to the default.</p>
+
+<h2>Help and support</h2>
+
+<p>If you have any problems, ask a developer on your team (if you have one), <a href="mailto:england.service-manual@nhs.net?subject=NHS.UK prototype kit - Updating the kit">email us</a> or get in touch on the <a href="https://nhs-service-manual.slack.com/messages/CFYL2GDGW" rel="nofollow">NHS digital service manual #prototype-kit Slack channel</a>.</p>
+
+      {% include "how-tos/includes/back-button.html" %}
+
+    </div>
+
   </div>
-</div>
 {% endblock %}

--- a/app/views/how-tos/switching-from-govuk-prototype-kit.html
+++ b/app/views/how-tos/switching-from-govuk-prototype-kit.html
@@ -1,120 +1,119 @@
-{% extends 'layout.html' %}
+{% extends 'layout.html' %} {% block pageTitle %} Switching from the GOV.UK
+Prototype Kit - NHS.UK prototype kit {% endblock %} {% block beforeContent %} {%
+include "how-tos/includes/breadcrumb.html" %} {% endblock %} {% block content %}
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-two-thirds">
+    <h1 class="nhsuk-heading-xl">Switching from the GOV.UK prototype kit</h1>
 
-{% block pageTitle %}
-  Switching from the GOV.UK Prototype Kit - NHS.UK prototype kit
-{% endblock %}
-
-{% block beforeContent %}
-  {% include "how-tos/includes/breadcrumb.html" %}
-{% endblock %}
-
-{% block content %}
-  <div class="nhsuk-grid-row">
-
-    <div class="nhsuk-grid-column-two-thirds">
-
-      <h1 class="nhsuk-heading-xl">
-        Switching from the GOV.UK prototype kit
-      </h1>
-
-
-<p>
-      If you have learned how to use the <a href="https://prototype-kit.service.gov.uk/docs/">GOV.UK Prototype Kit</a>, you will be able to use the NHS.UK prototype kit. This is because the two prototype kits are built in the same way. However, you must do some things differently.
+    <p>
+      If you have learned how to use the
+      <a href="https://prototype-kit.service.gov.uk/docs/"
+        >GOV.UK Prototype Kit</a
+      >, you will be able to use the NHS.UK prototype kit. This is because the
+      two prototype kits are built in the same way. However, you must do some
+      things differently.
     </p>
-<h2 class="nhsuk-heading-m">Installing and running the NHS.UK prototype kit</h2>
+    <h2 class="nhsuk-heading-m">
+      Installing and running the NHS.UK prototype kit
+    </h2>
 
-<p>
-When you are installing and running your prototype:
+    <p>When you are installing and running your prototype:</p>
 
-{{ list({
-  title: "Do",
-  type: "tick",
-  items: [
-  {
-    item: '<a href="/install/advanced">download the kit using the zip file or Github</a>'
-  },
-    {
-      item: 'check when you install your prototype that you are using the right version of Node.js - you may need to install and use a different version. If you need to make prototypes for both NHS.UK and GOV.UK you can switch versions of node with a <a href="https://github.com/nvm-sh/nvm">node version manager</a>'
-    },
-    {
-      item: 'start your local server by entering in the terminal: <pre class="app-pre"><code class="language-markup">npm run watch</code></pre> '
-    }
-  ]
-}) }}
+    {{ list({ title: "Do", type: "tick", items: [ { item: '<a
+      href="/install/advanced"
+      >download the kit using the zip file or Github</a
+    >' }, { item: 'check when you install your prototype that you are using the
+    right version of Node.js - you may need to install and use a different
+    version. If you need to make prototypes for both NHS.UK and GOV.UK you can
+    switch versions of node with a
+    <a href="https://github.com/nvm-sh/nvm">node version manager</a>' }, { item:
+    'start your local server by entering in the terminal:
+    <pre
+      class="app-pre"
+    ><code class="language-markup">npm run watch</code></pre>
+    ' } ] }) }} {{ list({ title: "Don’t", type: "cross", items: [ { item: 'try
+    to create a prototype by running a command in the terminal - you must
+    download it' }, { item: 'start your local server the same way as in the
+    GOV.UK Prototype Kit as it will not work' } ] }) }}
 
-{{ list({
-  title: "Don’t",
-  type: "cross",
-  items: [
-  {
-    item: 'try to create a prototype by running a command in the terminal - you must download it'
-  },
-    {
-      item: 'start your local server the same way as in the GOV.UK Prototype Kit as it will not work'
-    }
-  ]
-}) }}
+    <h2>Making pages</h2>
 
+    <p>When you are making pages:</p>
 
+    {{ list({ title: "Do", type: "tick", items: [ { item: 'use the NHS.UK design
+    system for
+    <a href="https://service-manual.nhs.uk/design-system/styles">styles</a>,
+    <a href="https://service-manual.nhs.uk/design-system/components"
+      >components</a
+    >
+    and
+    <a href="https://service-manual.nhs.uk/design-system/patterns">patterns</a>
+    - you can also copy
+    <a href="/page-templates">template pages in the NHS prototype kit</a>' }, {
+    item: 'use
+    <a href="https://service-manual.nhs.uk/design-system"
+      >NHS.UK macro naming conventions</a
+    >
+    which do not have a prefix, for example
+    <code class="language-markup">{{ radios }}</code> instead of
+    <code class="language-markup">{{ govukRadios }}</code>' }, { item: 'use
+    <a href="https://service-manual.nhs.uk/design-system/styles/typography"
+      >NHS.UK typography classes</a
+    >
+    on headings and other text, for example
+    <pre
+      class="app-pre"
+    ><code class="language-markup">' + '<p class="nhsuk-body">nhsuk-body</p>' | escape  + '</code></pre>
+    ' }, { item: 'know that the NHS.UK prototype kit does not have some
+    functionality that is in the GOV.UK one, for example the interface to create
+    pages from templates' }, { item: 'know that plugins designed for the GOV.UK
+    Prototype Kit may not work or may need to be installed differently - for
+    example, if you want to use the
+    <a href="https://x-govuk.github.io/govuk-prototype-filters/get-started/"
+      >GOV.UK Prototype Kit Filters plugin</a
+    >
+    you must use instructions for earlier versions of the kit and make changes
+    in <code class="language-markup">filters.js</code>.' } ] }) }} {{ list({
+    title: "Don’t", type: "cross", items: [ { item: 'copy pages from the GOV.UK
+    design system or GOV.UK prototype kit and expect them to work - you may need
+    to copy over extra code like CSS to make them work properly' }, { item: 'use
+    GOV.UK macro naming conventions as they will not work' }, { item: 'use
+    GOV.UK typography classes as they will not work' } ] }) }}
+    <h2 class="nhsuk-heading-m">Using routing and session data</h2>
 
-<h2>Making pages</h2>
+    <p>
+      You can define routes to do branching logic or other custom behaviour in
+      the same way as the GOV.UK Prototype Kit.
+    </p>
 
-<p>
-  When you are making pages:
-</p>  
+    <p>
+      You can also add default session data in
+      <code class="language-markup">data/session-data-defaults.js</code>
+    </p>
 
-{{ list({
-  title: "Do",
-  type: "tick",
-  items: [
-    {
-      item: 'use the NHS.UK design system for <a href="https://service-manual.nhs.uk/design-system/styles">styles</a>, <a href="https://service-manual.nhs.uk/design-system/components">components</a> and <a href="https://service-manual.nhs.uk/design-system/patterns">patterns</a> - you can also copy <a href="/page-templates">template pages in the NHS prototype kit</a>'
-    },
-    {
-      item: 'use <a href="https://service-manual.nhs.uk/design-system">NHS.UK macro naming conventions</a> which do not have a prefix, for example <code class="language-markup">{{ radios }}</code> instead of <code class="language-markup">{{ govukRadios }}</code>'
-    },
-    {
-      item: 'use <a href="https://service-manual.nhs.uk/design-system/styles/typography">NHS.UK typography classes</a> on headings and other text, for example <pre class="app-pre"><code class="language-markup">' + '<p class="nhsuk-body">nhsuk-body</p>' | escape  + '</code></pre>'
-    },
-    {
-      item: 'know that the NHS.UK prototype kit does not have some functionality that is in the GOV.UK one, for example the interface to create pages from templates'
-   },
-   {
-      item: 'know that plugins designed for the GOV.UK Prototype Kit may not work or may need to be installed differently - for example, if you want to use the <a href="https://x-govuk.github.io/govuk-prototype-filters/get-started/">GOV.UK Prototype Kit Filters plugin</a> you must use instructions for earlier versions of the kit and make changes in <code class="language-markup">filters.js</code>.'
-    }
-  ]
-}) }}
+    <p>
+      Unlike the GOV.UK Prototype Kit, if you save any changes the the routes
+      file, the app will restart and any session data will revert to the
+      default.
+    </p>
 
-{{ list({
-  title: "Don’t",
-  type: "cross",
-  items: [
-    {
-      item: 'copy pages from the GOV.UK design system or GOV.UK prototype kit and expect them to work - you may need to copy over extra code like CSS to make them work properly'
-    },
-    {
-      item: 'use GOV.UK macro naming conventions as they will not work'
-    },
-    {
-      item: 'use GOV.UK typography classes as they will not work'
-    }
-  ]
-}) }}
-<h2 class="nhsuk-heading-m">Using routing and session data</h2>
+    <h2>Help and support</h2>
 
-<p>You can define routes to do branching logic or other custom behaviour in the same way as the GOV.UK Prototype Kit.</p>
+    <p>
+      If you have any problems, ask a developer on your team (if you have one),
+      <a
+        href="mailto:england.service-manual@nhs.net?subject=NHS.UK prototype kit - Updating the kit"
+        >email us</a
+      >
+      or get in touch on the
+      <a
+        href="https://nhs-service-manual.slack.com/messages/CFYL2GDGW"
+        rel="nofollow"
+        >NHS digital service manual #prototype-kit Slack channel</a
+      >.
+    </p>
 
-<p>You can also add default session data in <code class="language-markup">data/session-data-defaults.js</code></p>
-
-<p>Unlike the GOV.UK Prototype Kit, if you save any changes the the routes file, the app will restart and any session data will revert to the default.</p>
-
-<h2>Help and support</h2>
-
-<p>If you have any problems, ask a developer on your team (if you have one), <a href="mailto:england.service-manual@nhs.net?subject=NHS.UK prototype kit - Updating the kit">email us</a> or get in touch on the <a href="https://nhs-service-manual.slack.com/messages/CFYL2GDGW" rel="nofollow">NHS digital service manual #prototype-kit Slack channel</a>.</p>
-
-      {% include "how-tos/includes/back-button.html" %}
-
-    </div>
-
+    {% include "how-tos/includes/back-button.html" %}
   </div>
+</div>
 {% endblock %}

--- a/app/views/install/check-it-works.html
+++ b/app/views/install/check-it-works.html
@@ -28,7 +28,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        <span class="nhsuk-caption-l">Step 8 of 8: {{system | default ("[add operating system with 'system']")}}</span>
+        <span class="nhsuk-caption-l">Step 8 of 8{{[":", operatingSystem ] | join(" ") if operatingSystem }}</span>
         Check it works
       </h1>
 

--- a/app/views/install/check-it-works.html
+++ b/app/views/install/check-it-works.html
@@ -10,10 +10,15 @@
       {
         href: "/",
         text: "Home"
+      },
+      {
+        href: "/install",
+        text: "Get started"
       }
     ],
-    href: "/install",
-    text: "Get started"
+
+    href: "/install/simple",
+    text: "Install guide"
   }) }}
 {% endblock %}
 
@@ -23,7 +28,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        <span class="nhsuk-caption-l">Step 8 of 8</span>
+        <span class="nhsuk-caption-l">Step 8 of 8: {{system | default ("[add operating system with 'system']")}}</span>
         Check it works
       </h1>
 

--- a/app/views/install/download.html
+++ b/app/views/install/download.html
@@ -28,7 +28,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        <span class="nhsuk-caption-l">Step 4 of 8{% if system %}: {{system }}{% endif %}</span>
+        <span class="nhsuk-caption-l">Step 4 of 8{{[":", operatingSystem ] | join(" ") if operatingSystem }}</span>
         Download and decide where to keep your prototypes
       </h1>
 

--- a/app/views/install/download.html
+++ b/app/views/install/download.html
@@ -10,10 +10,15 @@
       {
         href: "/",
         text: "Home"
+      },
+      {
+        href: "/install",
+        text: "Get started"
       }
     ],
-    href: "/install",
-    text: "Get started"
+
+    href: "/install/simple",
+    text: "Install guide"
   }) }}
 {% endblock %}
 
@@ -23,7 +28,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        <span class="nhsuk-caption-l">Step 4 of 8</span>
+        <span class="nhsuk-caption-l">Step 4 of 8: {{system | default ("[add operating system with 'system']") }}</span>
         Download and decide where to keep your prototypes
       </h1>
 

--- a/app/views/install/download.html
+++ b/app/views/install/download.html
@@ -28,7 +28,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        <span class="nhsuk-caption-l">Step 4 of 8: {{system | default ("[add operating system with 'system']") }}</span>
+        <span class="nhsuk-caption-l">Step 4 of 8{% if system %}: {{system }}{% endif %}</span>
         Download and decide where to keep your prototypes
       </h1>
 

--- a/app/views/install/mac/check-it-works.html
+++ b/app/views/install/mac/check-it-works.html
@@ -1,4 +1,4 @@
-{% set system = "Mac" %}
+{% set operatingSystem = "Mac" %}
 
 {% extends "install/check-it-works.html" %}
 

--- a/app/views/install/mac/check-it-works.html
+++ b/app/views/install/mac/check-it-works.html
@@ -1,3 +1,5 @@
+{% set system = "Mac" %}
+
 {% extends "install/check-it-works.html" %}
 
 {% block branchingContent %}

--- a/app/views/install/mac/download.html
+++ b/app/views/install/mac/download.html
@@ -1,4 +1,4 @@
-{% set system = "Mac" %}
+{% set operatingSystem = "Mac" %}
 {% extends "install/download.html" %}
 
 {% block branchingContent %}

--- a/app/views/install/mac/download.html
+++ b/app/views/install/mac/download.html
@@ -1,3 +1,4 @@
+{% set system = "Mac" %}
 {% extends "install/download.html" %}
 
 {% block branchingContent %}

--- a/app/views/install/mac/node.html
+++ b/app/views/install/mac/node.html
@@ -1,3 +1,4 @@
+{% set system = "Mac" %}
 {% extends "install/node.html" %}
 
 {% block branchingContent %}

--- a/app/views/install/mac/node.html
+++ b/app/views/install/mac/node.html
@@ -1,4 +1,4 @@
-{% set system = "Mac" %}
+{% set operatingSystem = "Mac" %}
 {% extends "install/node.html" %}
 
 {% block branchingContent %}

--- a/app/views/install/mac/open.html
+++ b/app/views/install/mac/open.html
@@ -1,4 +1,4 @@
-{% set system = "Mac" %}
+{% set operatingSystem = "Mac" %}
 {% extends "install/open.html" %}
 
 {% block branchingContent %}

--- a/app/views/install/mac/open.html
+++ b/app/views/install/mac/open.html
@@ -1,3 +1,4 @@
+{% set system = "Mac" %}
 {% extends "install/open.html" %}
 
 {% block branchingContent %}

--- a/app/views/install/mac/run.html
+++ b/app/views/install/mac/run.html
@@ -1,4 +1,4 @@
-{% set system = "Mac" %}
+{% set operatingSystem = "Mac" %}
 {% extends "install/run.html" %}
 
 {% block branchingContent %}

--- a/app/views/install/mac/run.html
+++ b/app/views/install/mac/run.html
@@ -1,3 +1,4 @@
+{% set system = "Mac" %}
 {% extends "install/run.html" %}
 
 {% block branchingContent %}

--- a/app/views/install/mac/setup.html
+++ b/app/views/install/mac/setup.html
@@ -1,3 +1,4 @@
+{% set system = "Mac" %}
 {% extends "install/setup.html" %}
 
 {% block branchingContent %}

--- a/app/views/install/mac/setup.html
+++ b/app/views/install/mac/setup.html
@@ -1,4 +1,4 @@
-{% set system = "Mac" %}
+{% set operatingSystem = "Mac" %}
 {% extends "install/setup.html" %}
 
 {% block branchingContent %}

--- a/app/views/install/mac/terminal.html
+++ b/app/views/install/mac/terminal.html
@@ -1,4 +1,4 @@
-{% set system = "Mac" %}
+{% set operatingSystem = "Mac" %}
 {% extends "install/terminal.html" %}
 
 {% block branchingTitle %}

--- a/app/views/install/mac/terminal.html
+++ b/app/views/install/mac/terminal.html
@@ -1,3 +1,4 @@
+{% set system = "Mac" %}
 {% extends "install/terminal.html" %}
 
 {% block branchingTitle %}

--- a/app/views/install/mac/text-editor.html
+++ b/app/views/install/mac/text-editor.html
@@ -1,4 +1,4 @@
-{% set system = "Mac" %}
+{% set operatingSystem = "Mac" %}
 {% extends "install/text-editor.html" %}
 
 {% block pagination %}

--- a/app/views/install/mac/text-editor.html
+++ b/app/views/install/mac/text-editor.html
@@ -1,3 +1,4 @@
+{% set system = "Mac" %}
 {% extends "install/text-editor.html" %}
 
 {% block pagination %}

--- a/app/views/install/node.html
+++ b/app/views/install/node.html
@@ -10,10 +10,15 @@
       {
         href: "/",
         text: "Home"
+      },
+      {
+        href: "/install",
+        text: "Get started"
       }
     ],
-    href: "/install",
-    text: "Get started"
+
+    href: "/install/simple",
+    text: "Install guide"
   }) }}
 {% endblock %}
 
@@ -23,7 +28,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        <span class="nhsuk-caption-l">Step 2 of 8</span>
+        <span class="nhsuk-caption-l">Step 2 of 8: {{system | default ("[add operating system with 'system']") }}</span>
         Node.js LTS version
       </h1>
 

--- a/app/views/install/node.html
+++ b/app/views/install/node.html
@@ -28,7 +28,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        <span class="nhsuk-caption-l">Step 2 of 8: {{system | default ("[add operating system with 'system']") }}</span>
+        <span class="nhsuk-caption-l">Step 2 of 8{% if system %}: {{system }}{% endif %}</span>
         Node.js LTS version
       </h1>
 

--- a/app/views/install/node.html
+++ b/app/views/install/node.html
@@ -28,7 +28,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        <span class="nhsuk-caption-l">Step 2 of 8{% if system %}: {{system }}{% endif %}</span>
+        <span class="nhsuk-caption-l">Step 2 of 8{{[":", operatingSystem ] | join(" ") if operatingSystem }}</span>
         Node.js LTS version
       </h1>
 

--- a/app/views/install/open.html
+++ b/app/views/install/open.html
@@ -28,7 +28,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        <span class="nhsuk-caption-l">Step 5 of 8: {{system | default ("[add operating system with 'system']")}} </span>
+        <span class="nhsuk-caption-l">Step 5 of 8{{[":", operatingSystem ] | join(" ") if operatingSystem }}</span>
         Go to your prototype
       </h1>
 

--- a/app/views/install/open.html
+++ b/app/views/install/open.html
@@ -10,10 +10,15 @@
       {
         href: "/",
         text: "Home"
+      },
+      {
+        href: "/install",
+        text: "Get started"
       }
     ],
-    href: "/install",
-    text: "Get started"
+
+    href: "/install/simple",
+    text: "Install guide"
   }) }}
 {% endblock %}
 
@@ -23,7 +28,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        <span class="nhsuk-caption-l">Step 5 of 8</span>
+        <span class="nhsuk-caption-l">Step 5 of 8: {{system | default ("[add operating system with 'system']")}} </span>
         Go to your prototype
       </h1>
 

--- a/app/views/install/run.html
+++ b/app/views/install/run.html
@@ -10,10 +10,15 @@
       {
         href: "/",
         text: "Home"
+      },
+      {
+        href: "/install",
+        text: "Get started"
       }
     ],
-    href: "/install",
-    text: "Get started"
+
+    href: "/install/simple",
+    text: "Install guide"
   }) }}
 {% endblock %}
 
@@ -23,7 +28,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        <span class="nhsuk-caption-l">Step 7 of 8</span>
+        <span class="nhsuk-caption-l">Step 7 of 8: {{system | default ("[add operating system with 'system']") }}</span>
         Run the kit
       </h1>
 

--- a/app/views/install/run.html
+++ b/app/views/install/run.html
@@ -28,7 +28,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        <span class="nhsuk-caption-l">Step 7 of 8: {{system | default ("[add operating system with 'system']") }}</span>
+        <span class="nhsuk-caption-l">Step 7 of 8{{[":", operatingSystem ] | join(" ") if operatingSystem }}</span>
         Run the kit
       </h1>
 

--- a/app/views/install/setup.html
+++ b/app/views/install/setup.html
@@ -28,7 +28,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        <span class="nhsuk-caption-l">Step 6 of 8: {{system | default ("[add operating system with 'system']") }}</span>
+        <span class="nhsuk-caption-l">Step 6 of 8{{[":", operatingSystem ] | join(" ") if operatingSystem }}</span>
         Setup the kit
       </h1>
 

--- a/app/views/install/setup.html
+++ b/app/views/install/setup.html
@@ -10,10 +10,15 @@
       {
         href: "/",
         text: "Home"
+      },
+      {
+        href: "/install",
+        text: "Get started"
       }
     ],
-    href: "/install",
-    text: "Get started"
+
+    href: "/install/simple",
+    text: "Install guide"
   }) }}
 {% endblock %}
 
@@ -23,7 +28,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        <span class="nhsuk-caption-l">Step 6 of 8</span>
+        <span class="nhsuk-caption-l">Step 6 of 8: {{system | default ("[add operating system with 'system']") }}</span>
         Setup the kit
       </h1>
 

--- a/app/views/install/terminal.html
+++ b/app/views/install/terminal.html
@@ -10,10 +10,15 @@
       {
         href: "/",
         text: "Home"
+      },
+      {
+        href: "/install",
+        text: "Get started"
       }
     ],
-    href: "/install",
-    text: "Get started"
+
+    href: "/install/simple",
+    text: "Install guide"
   }) }}
 {% endblock %}
 
@@ -23,7 +28,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        <span class="nhsuk-caption-l">Step 1 of 8</span>
+        <span class="nhsuk-caption-l">Step 1 of 8: {{system | default ("[add operating system with 'system']") }}</span>
         {% block branchingHeader %}Terminal{% endblock %}
       </h1>
 

--- a/app/views/install/terminal.html
+++ b/app/views/install/terminal.html
@@ -28,7 +28,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        <span class="nhsuk-caption-l">Step 1 of 8: {{system | default ("[add operating system with 'system']") }}</span>
+        <span class="nhsuk-caption-l">Step 1 of 8{{[":", operatingSystem ] | join(" ") if operatingSystem }}</span>
         {% block branchingHeader %}Terminal{% endblock %}
       </h1>
 

--- a/app/views/install/text-editor.html
+++ b/app/views/install/text-editor.html
@@ -28,7 +28,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        <span class="nhsuk-caption-l">Step 3 of 8: {{system | default ("[add operating system with 'system']") }}</span>
+        <span class="nhsuk-caption-l">Step 3 of 8{{[":", operatingSystem ] | join(" ") if operatingSystem }}</span>
         HTML text editor
       </h1>
 

--- a/app/views/install/text-editor.html
+++ b/app/views/install/text-editor.html
@@ -10,10 +10,15 @@
       {
         href: "/",
         text: "Home"
+      },
+      {
+        href: "/install",
+        text: "Get started"
       }
     ],
-    href: "/install",
-    text: "Get started"
+
+    href: "/install/simple",
+    text: "Install guide"
   }) }}
 {% endblock %}
 
@@ -23,7 +28,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        <span class="nhsuk-caption-l">Step 3 of 8</span>
+        <span class="nhsuk-caption-l">Step 3 of 8: {{system | default ("[add operating system with 'system']") }}</span>
         HTML text editor
       </h1>
 

--- a/app/views/install/windows/check-it-works.html
+++ b/app/views/install/windows/check-it-works.html
@@ -1,4 +1,4 @@
-{% set system = "Windows" %}
+{% set operatingSystem = "Windows" %}
 {% extends "install/check-it-works.html" %}
 
 {% block branchingContent %}

--- a/app/views/install/windows/check-it-works.html
+++ b/app/views/install/windows/check-it-works.html
@@ -1,3 +1,4 @@
+{% set system = "Windows" %}
 {% extends "install/check-it-works.html" %}
 
 {% block branchingContent %}

--- a/app/views/install/windows/download.html
+++ b/app/views/install/windows/download.html
@@ -1,3 +1,4 @@
+{% set system = "Windows" %}
 {% extends "install/download.html" %}
 
 {% block branchingContent %}

--- a/app/views/install/windows/download.html
+++ b/app/views/install/windows/download.html
@@ -1,4 +1,4 @@
-{% set system = "Windows" %}
+{% set operatingSystem = "Windows" %}
 {% extends "install/download.html" %}
 
 {% block branchingContent %}

--- a/app/views/install/windows/git-bash.html
+++ b/app/views/install/windows/git-bash.html
@@ -1,4 +1,4 @@
-{% set system = "Windows" %}
+{% set operatingSystem = "Windows" %}
 
 {% extends "install/terminal.html" %}
 

--- a/app/views/install/windows/git-bash.html
+++ b/app/views/install/windows/git-bash.html
@@ -1,3 +1,5 @@
+{% set system = "Windows" %}
+
 {% extends "install/terminal.html" %}
 
 {% block pageTitle %}

--- a/app/views/install/windows/node.html
+++ b/app/views/install/windows/node.html
@@ -1,3 +1,5 @@
+{% set system = "Windows" %}
+
 {% extends "install/node.html" %}
 
 {% block branchingContent %}

--- a/app/views/install/windows/node.html
+++ b/app/views/install/windows/node.html
@@ -1,4 +1,4 @@
-{% set system = "Windows" %}
+{% set operatingSystem = "Windows" %}
 
 {% extends "install/node.html" %}
 

--- a/app/views/install/windows/open.html
+++ b/app/views/install/windows/open.html
@@ -1,4 +1,4 @@
-{% set system = "Windows" %}
+{% set operatingSystem = "Windows" %}
 {% extends "install/open.html" %}
 
 {% block branchingContent %}

--- a/app/views/install/windows/open.html
+++ b/app/views/install/windows/open.html
@@ -1,3 +1,4 @@
+{% set system = "Windows" %}
 {% extends "install/open.html" %}
 
 {% block branchingContent %}

--- a/app/views/install/windows/run.html
+++ b/app/views/install/windows/run.html
@@ -1,3 +1,5 @@
+
+
 {% extends "install/run.html" %}
 
 {% block branchingContent %}

--- a/app/views/install/windows/run.html
+++ b/app/views/install/windows/run.html
@@ -1,5 +1,4 @@
-
-
+{% set system = "Windows" %}
 {% extends "install/run.html" %}
 
 {% block branchingContent %}

--- a/app/views/install/windows/run.html
+++ b/app/views/install/windows/run.html
@@ -1,4 +1,4 @@
-{% set system = "Windows" %}
+{% set operatingSystem = "Windows" %}
 {% extends "install/run.html" %}
 
 {% block branchingContent %}

--- a/app/views/install/windows/setup.html
+++ b/app/views/install/windows/setup.html
@@ -1,4 +1,4 @@
-{% set system = "Windows" %}
+{% set operatingSystem = "Windows" %}
 {% extends "install/setup.html" %}
 
 {% block branchingContent %}

--- a/app/views/install/windows/setup.html
+++ b/app/views/install/windows/setup.html
@@ -1,3 +1,4 @@
+{% set system = "Windows" %}
 {% extends "install/setup.html" %}
 
 {% block branchingContent %}

--- a/app/views/install/windows/terminal.html
+++ b/app/views/install/windows/terminal.html
@@ -1,4 +1,4 @@
-{% set system = "Windows" %}
+{% set operatingSystem = "Windows" %}
 
 {% extends "install/terminal.html" %}
 

--- a/app/views/install/windows/terminal.html
+++ b/app/views/install/windows/terminal.html
@@ -1,3 +1,5 @@
+{% set system = "Windows" %}
+
 {% extends "install/terminal.html" %}
 
 {% block pageTitle %}

--- a/app/views/install/windows/text-editor.html
+++ b/app/views/install/windows/text-editor.html
@@ -1,3 +1,5 @@
+{% set system = "Windows" %}
+
 {% extends "install/text-editor.html" %}
 
 {% block pagination %}

--- a/app/views/install/windows/text-editor.html
+++ b/app/views/install/windows/text-editor.html
@@ -1,4 +1,4 @@
-{% set system = "Windows" %}
+{% set operatingSystem = "Windows" %}
 
 {% extends "install/text-editor.html" %}
 


### PR DESCRIPTION
Added:
- breadcrumb at top of pages of operating-model specific steps to link back to start of install guide https://prototype-kit.service-manual.nhs.uk/install/simple . Not added to system choice as this is a switcher page and has a link at the bottom to get back to the install home
- variable on steps to show operation system (windows or mac) set on the child pages with a nunjucks variable (this is used rather than the data from the radio buttons in case someone comes to the pages directly as choosing your operating system is only for triaging to the right pages). System added after steps to be reassurance but less repetitive than being at the beginning (Mac: Step 1 of 8) 

The advanced guide is not changed as it is one level down from the get started guide and a single page so does not need extra breadcrumbs.

## Description

### Mac guide
| Before | After |
| -------| ------ |
| <img width="657" alt="Mac install guide page as-is with breadcrumb link to 'Get started' and 'step 1 of 8' " src="https://github.com/user-attachments/assets/d729df14-cb38-4428-8b7f-acbdb0c8387f"> |  <img width="693" alt="Mac install guide page with breadcrumb link to 'Get started' and 'Install guide' and 'step 1 of 8: Mac'" src="https://github.com/user-attachments/assets/3bde8a63-ff80-4027-ae0e-53a6e3336e11"> |  
| <img width="678" alt="Mac install guide page as-is with breadcrumb link to 'Get started' and 'step 2 of 8' " src="https://github.com/user-attachments/assets/f9bf1248-bfa1-4d1e-ab9e-0fef4d1b29cd"> | <img width="657" alt="Mac install guide page with breadcrumb link to 'Get started' and 'Install guide' and 'step 2 of 8: Mac'"  src="https://github.com/user-attachments/assets/fe549028-8ebe-4b7f-9ff4-8143cce9bd40"> |
 | <img width="662" alt="Mac install guide page as-is with breadcrumb link to 'Get started' and 'step 3 of 8'" src="https://github.com/user-attachments/assets/0d8cb02c-0cc9-40f2-a27a-f798b23ecb96"> | <img width="639" alt="Mac install guide page with breadcrumb link to 'Get started' and 'Install guide' and 'step 3 of 8: Mac'"  src="https://github.com/user-attachments/assets/899f087c-b72c-4b7b-976c-3e94e39bb196" >|
| <img width="552" alt="Mac install guide page as-is with breadcrumb link to 'Get started' and 'step 4 of 8'" src="https://github.com/user-attachments/assets/9d68236f-0a52-4916-852a-01e31be985b4"> |  <img width="532" alt="Mac install guide page with breadcrumb link to 'Get started' and 'Install guide' and 'step 4 of 8: Mac'" src="https://github.com/user-attachments/assets/6be83bf7-ede7-4a59-98d0-4b6a993cfc7c"> |
| <img width="530" alt="Mac install guide page as-is with breadcrumb link to 'Get started' and 'step 5 of 8'" src="https://github.com/user-attachments/assets/3e042c44-db91-4efe-86e5-c91e4768d93c"> | <img width="551" alt="Mac install guide page with breadcrumb link to 'Get started' and 'Install guide' and 'step 5 of 8: Mac'"  src="https://github.com/user-attachments/assets/520503a3-3b3c-46d8-930b-6f0f16083837"> |
| <img width="647" alt="Mac install guide page as-is with breadcrumb link to 'Get started' and 'step 6 of 8'" src="https://github.com/user-attachments/assets/1891b662-0457-4900-afbd-d6a090248574"> | <img width="641" alt="Mac install guide page with breadcrumb link to 'Get started' and 'Install guide' and 'step 6 of 8: Mac'"   src="https://github.com/user-attachments/assets/6a053fdb-3ade-44fd-93c7-de31d9374685"> | 
| <img width="659" alt="Mac install guide page as-is with breadcrumb link to 'Get started' and 'step 7 of 8'"  src="https://github.com/user-attachments/assets/a718b94c-7926-494f-992d-99f8869f570b"> |  <img width="652" alt="Mac install guide page with breadcrumb link to 'Get started' and 'Install guide' and 'step 7 of 8: Mac'"    src="https://github.com/user-attachments/assets/da5bb8f3-f31d-4855-874a-49342b81635e"> |
 | <img width="612" alt="Mac install guide page as-is with breadcrumb link to 'Get started' and 'step 8 of 8'" src="https://github.com/user-attachments/assets/af19a176-021f-4e64-9b29-525c2e7ce723"> | <img width="609" alt="Mac install guide page with breadcrumb link to 'Get started' and 'Install guide' and 'step 8 of 8: Mac'"  src="https://github.com/user-attachments/assets/5839baae-171f-41a8-ac71-10e95ee65d4d"> | 

### WIndows guide

| Before | After |
| -------| ------ |
| <img width="634" alt="Window install guide page as-is with breadcrumb link to 'Get started' and 'step 1 of 8' " src="https://github.com/user-attachments/assets/9116875c-9671-4b18-b625-8b959951ec20"> | <img width="630" alt="Window install guide page with breadcrumb link to 'Get started' and 'Install guide' and 'step 1 of 8: Windows'" src="https://github.com/user-attachments/assets/e4b8001d-f0cd-4b17-bd52-6297c38e51df"> | 
| <img width="651" alt="Window install guide page as-is with breadcrumb link to 'Get started' and 'step 2 of 8' "  src="https://github.com/user-attachments/assets/f8cc97d6-009e-4bd7-9f1e-5f290d9e739f"> |  <img width="642" alt="Window install guide page with breadcrumb link to 'Get started' and 'Install guide' and 'step 2 of 8: Windows'"  src="https://github.com/user-attachments/assets/68ae7f4d-c8ad-4dbf-9791-2141b9b5fc07"> |
| <img width="663" alt="Window install guide page as-is with breadcrumb link to 'Get started' and 'step 3 of 8' "   src="https://github.com/user-attachments/assets/94a422d6-5c63-49f0-a9af-588ef899d7b7"> | <img width="669" alt="Window install guide page with breadcrumb link to 'Get started' and 'Install guide' and 'step 3 of 8: Windows'"   src="https://github.com/user-attachments/assets/b7551d8c-4030-45a4-8259-8c61f75aa04c"> | 
|  <img width="543" alt="Window install guide page as-is with breadcrumb link to 'Get started' and 'step 4 of 8' "    src="https://github.com/user-attachments/assets/1dbcd690-73e0-40c5-88f4-eb54294f15f1">  |  <img width="567" alt="Window install guide page with breadcrumb link to 'Get started' and 'Install guide' and 'step 4 of 8: Windows'"    src="https://github.com/user-attachments/assets/f377bf4d-c416-42b8-9ba2-e993227d51b7"> | 
|  <img width="525"  alt="Window install guide page as-is with breadcrumb link to 'Get started' and 'step 5 of 8' "    src="https://github.com/user-attachments/assets/9b9e049b-a50e-4dcf-a7f0-a4149efbefc2"> | <img width="566" alt="Window install guide page with breadcrumb link to 'Get started' and 'Install guide' and 'step 5 of 8: Windows'" src="https://github.com/user-attachments/assets/002394d0-4b50-4259-a0f9-86e3927bcb62"> |
| <img width="643"  alt="Window install guide page as-is with breadcrumb link to 'Get started' and 'step 6 of 8' " src="https://github.com/user-attachments/assets/7c65794b-40cb-44c4-aaa7-5206c0caed9f"> | <img width="656" alt="Window install guide page with breadcrumb link to 'Get started' and 'Install guide' and 'step 6 of 8: Windows'" src="https://github.com/user-attachments/assets/4e4bdfb0-7018-4369-863b-3a7f4751e039">  |
| <img width="650" alt="Window install guide page as-is with breadcrumb link to 'Get started' and 'step 7 of 8' "  src="https://github.com/user-attachments/assets/6fcc567d-5f2e-4461-888c-c79921394929"> | <img width="651" alt="Window install guide page with breadcrumb link to 'Get started' and 'Install guide' and 'step 7 of 8: Windows'"  src="https://github.com/user-attachments/assets/87c23ce0-7246-41c9-ba56-d399cf22e72b"> |
| <img width="623" alt="Window install guide page as-is with breadcrumb link to 'Get started' and 'step 8 of 8'" src="https://github.com/user-attachments/assets/8b5100a0-cc2c-482d-b939-77df70c907cc"> | <img width="625" alt="Window install guide page with breadcrumb link to 'Get started' and 'Install guide' and 'step 8 of 8: Windows'"  src="https://github.com/user-attachments/assets/344b90b9-65ea-4538-b864-81eef66094fd"> |






## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] CHANGELOG entry
