### PR TITLE
change link to go to tutorial and how tos

### DIFF
--- a/app/views/install/check-it-works.html
+++ b/app/views/install/check-it-works.html
@@ -60,7 +60,8 @@
       <p>The kit is now installed. Congratulations!</p>
 
       <h2>Getting going</h2>
-      <p><a href="/how-tos/making-pages">Start making pages</a></p>
+      <p><a href="/how-tos/build-basic-prototype/index">Build a basic prototype</a> or view other <a href="/how-tos/index">how to guides</a>.</p>
+      
       {% block pagination %}
       {% endblock %}
 


### PR DESCRIPTION
## Description

Change guide to go from make pages to start of tutorial.

> <p><a href="/how-tos/build-basic-prototype/index">Build a basic prototype</a> or view other <a href="/how-tos/index">how to guides</a>.</p>

This is done in the main file that cascades to both mac and windows versions.

| Before | After |
| ---- | ---- |
|  <img width="269" alt="old version linking to make pages" src="https://github.com/user-attachments/assets/dc418411-9fb5-41cb-8432-182b1c54b1d9"> | <img width="252" alt="new version linking to both start of tutorial and how to guides" src="https://github.com/user-attachments/assets/f217733a-7e93-46f6-b0e0-62f0e1ccbe1d"> |  

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] CHANGELOG entry
