### PR TITLE
Remove back link from bottom of pages

### DIFF
--- a/app/views/examples/branching/answer-no.html
+++ b/app/views/examples/branching/answer-no.html
@@ -6,6 +6,13 @@
   Example - Branching - No
 {% endblock %}
 
+{% block beforeContent %}
+  {{ backLink({
+    href: "/examples/branching",
+    text: "Back"
+  }) }}
+{% endblock %}
+
 {% block content %}
 
   <div class="nhsuk-grid-row">
@@ -18,11 +25,6 @@
         <p>
           You do not know your NHS number.
         </p>
-
-        {{ backLink({
-          "href": "/examples/branching",
-          "text": "Back to How to do branching"
-        }) }}
 
     </div>
   </div>

--- a/app/views/examples/branching/answer-yes.html
+++ b/app/views/examples/branching/answer-yes.html
@@ -6,8 +6,14 @@
   Example - Branching - Yes
 {% endblock %}
 
-{% block content %}
+{% block beforeContent %}
+  {{ backLink({
+    href: "/examples/branching",
+    text: "Back"
+  }) }}
+{% endblock %}
 
+{% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
@@ -18,11 +24,6 @@
         <p>
           You know your NHS number.
         </p>
-
-        {{ backLink({
-          "href": "/examples/branching",
-          "text": "Back to How to do branching"
-        }) }}
 
     </div>
   </div>

--- a/app/views/examples/branching/index.html
+++ b/app/views/examples/branching/index.html
@@ -55,11 +55,6 @@
 
       </form>
 
-      {{ backLink({
-        "href": "/how-tos",
-        "text": "Back to How to guides"
-      }) }}
-
     </div>
   </div>
 {% endblock %}

--- a/app/views/how-tos/adding-assets.html
+++ b/app/views/how-tos/adding-assets.html
@@ -18,17 +18,17 @@
       </h1>
 
       <p>The prototype kit comes with standard NHS.UK frontend styles and components for you to use in your prototypes. However if you need to add your own CSS (Cascading Style Sheets), JavaScript or images, use the <code class="app-code">/app/assets</code> folder.</p>
-      
+
       <p>The prototype kit processes all the files in the <code class="app-code">/app/assets</code> folder, and puts the processed files in <code class="app-code">/public</code>.</p>
-      
+
       <p>Do not change files in the <code class="app-code">/public</code> folder because it’s deleted and rebuilt every time you make a change to your prototype.</p>
-      
+
       <h2 id="css">CSS</h2>
-      
+
       <p>CSS lets you change how web pages look, for example text sizes, colours or spacing.</p>
-      
+
       <p>To add universal styles use:</p>
-      
+
       <pre class="app-pre"><code class="app-code">/app/assets/sass/main.scss</code></pre>
 
       <p>Styles can also be added to individual templates via the "customStyles" template block:</p>
@@ -39,52 +39,49 @@
             body { background-color: pink; }
           &lt;/STYLE&gt;
         {{'{% endblock %}'}}</code></pre>
-        
-      
+
+
       <p>Do not edit the file <code class="app-code">/public/styles/main.css</code> because it’s deleted and rebuilt every time you make a change to your prototype.</p>
-      
+
       <p>The prototype kit uses <a href="https://sass-lang.com/guide">Sass</a>, which adds extra features to CSS.</p>
-      
+
       <h3 id="using-import">Using import</h3>
-      
+
       <p>If you have a very long main.scss file, you can split it up into multiple files and import those into <code class="app-code">main.scss</code>. Use an underscore (_) at the start of the import file filenames, for example:</p>
-      
+
       <pre class="app-pre"><code class="app-code">/app/assets/sass/_admin.scss</code></pre><p>Import this file into your <code class="app-code">main.scss</code> file without the underscore:</p>
-      
+
       <pre class="app-pre"><code class="app-code">@import "admin";</code></pre><h2 id="javascript">JavaScript</h2>
-      
+
       <p>You can use JavaScript to make changes to a web page without loading a new one. For example a user could enter some numbers, then JavaScript displays the results of a calculation without loading a new page.</p>
-      
+
       <p>To add JavaScript use:</p>
-      
+
       <pre class="app-pre"><code class="app-code">/app/assets/javascripts/main.js</code></pre><p>Do not edit the file <code class="app-code">/public/javascript/main.js</code> because it’s deleted and rebuilt every time you make a change to your prototype.</p>
-      
+
       <h2 id="images">Images</h2>
-      
+
       <p>If you add images to <code class="app-code">/app/assets/images</code> the prototype kit will copy them to <code class="app-code">/public</code>.</p>
-      
+
       <p>For example if you add an image:</p>
-      
+
       <pre class="app-pre"><code class="app-code">/app/assets/images/user.png</code></pre>
-      
+
       <p>Use it in your page like this:</p>
-      
+
       <pre class="app-pre"><code class="app-code">&lt;img src="/images/user.png" alt="User icon"&gt;</code></pre><p>Use ‘alt’ text to describe the image for screen readers.</p>
-      
+
       <p>Do not put files directly in <code class="app-code">/public</code> because it’s deleted and rebuilt every time you make a change to your prototype.</p>
-      
+
       <h2 id="other-files">Other files</h2>
-      
+
       <p>If you need to use other files in your prototype, you can add them to <code class="app-code">/app/assets</code> and the prototype kit will copy them to <code class="app-code">/public</code>. You can use sub-folders in the assets folder.</p>
-      
+
       <p>For example if you add a PDF:</p>
-      
+
       <pre class="app-pre"><code class="app-code">/app/assets/downloads/report.pdf</code></pre><p>Link to it like this:</p>
-      
+
       <pre class="app-pre"><code class="app-code">&lt;a href="/downloads/report.pdf"&gt;Download the report&lt;/a&gt;</code></pre><p>Do not put files directly in <code class="app-code">/public</code> because it’s deleted and rebuilt every time you make a change to your prototype.</p>
-
-      {% include "how-tos/includes/back-button.html" %}
-
     </div>
 
   </div>

--- a/app/views/how-tos/branching.html
+++ b/app/views/how-tos/branching.html
@@ -23,8 +23,6 @@
 
       <pre class="app-pre"><code class="app-code">/documentation_routes.js<br>docs/views/examples/branching</code></pre>
 
-      {% include "how-tos/includes/back-button.html" %}
-
     </div>
   </div>
 {% endblock %}

--- a/app/views/how-tos/build-basic-prototype/_BASE.njk
+++ b/app/views/how-tos/build-basic-prototype/_BASE.njk
@@ -41,9 +41,6 @@
   nextPage: next.title if next
 }) }}
 
-
-         {% include "how-tos/includes/back-button.html" %}
-
     </div>
 
   </div>

--- a/app/views/how-tos/build-basic-prototype/_BASE.njk
+++ b/app/views/how-tos/build-basic-prototype/_BASE.njk
@@ -16,24 +16,22 @@
 {% endblock %}
 
 {% block beforeContent %}
-{{ breadcrumb({
-  items: [
-    {
-      href: "/",
-      text: "Home"
-    },
-    {
-      href: "/how-tos",
-    text: "How to guides"
-    },
-    {
-      href: "/how-tos/build-basic-prototype/index",
-      text: "Build a basic prototype"
-    }
-  ]
-
-}) }}
-
+  {{ breadcrumb({
+    items: [
+      {
+        href: "/",
+        text: "Home"
+      },
+      {
+        href: "/how-tos",
+      text: "How to guides"
+      },
+      {
+        href: "/how-tos/build-basic-prototype/index",
+        text: "Build a basic prototype"
+      }
+    ]
+  }) }}
 {% endblock %}
 
 {% block content %}

--- a/app/views/how-tos/build-basic-prototype/_BASE.njk
+++ b/app/views/how-tos/build-basic-prototype/_BASE.njk
@@ -1,5 +1,5 @@
 {% extends 'layout.html' %}
-{% set sectionName = "Make a basic prototype" %}
+{% set sectionName = "Build a basic prototype" %}
 {# list of URLS, titles and questions for reference - existing NHS templates are hardcoded but these are tokenised for ease of change #}
 
 {% set exampleServiceName = "Order a test to check if you have magical powers" %}
@@ -16,7 +16,24 @@
 {% endblock %}
 
 {% block beforeContent %}
-  {% include "how-tos/includes/breadcrumb.html" %}
+{{ breadcrumb({
+  items: [
+    {
+      href: "/",
+      text: "Home"
+    },
+    {
+      href: "/how-tos",
+    text: "How to guides"
+    },
+    {
+      href: "/how-tos/build-basic-prototype/index",
+      text: "Build a basic prototype"
+    }
+  ]
+
+}) }}
+
 {% endblock %}
 
 {% block content %}

--- a/app/views/how-tos/build-basic-prototype/index.html
+++ b/app/views/how-tos/build-basic-prototype/index.html
@@ -4,7 +4,7 @@
 {% extends 'how-tos/build-basic-prototype/_BASE.njk' %}
 
 {% block beforeContent %}
-{% include "how-tos/includes/breadcrumb.html" %}
+  {% include "how-tos/includes/breadcrumb.html" %}
 {% endblock %}
 
 {% block makePrototype %}

--- a/app/views/how-tos/build-basic-prototype/index.html
+++ b/app/views/how-tos/build-basic-prototype/index.html
@@ -3,6 +3,10 @@
 
 {% extends 'how-tos/build-basic-prototype/_BASE.njk' %}
 
+{% block beforeContent %}
+{% include "how-tos/includes/breadcrumb.html" %}
+{% endblock %}
+
 {% block makePrototype %}
 
 <p>

--- a/app/views/how-tos/components.html
+++ b/app/views/how-tos/components.html
@@ -18,7 +18,7 @@
       </h1>
 
       <p class="nhsuk-lede-text">Components are reusable parts of the user interface, like buttons, text inputs and checkboxes.</p>
-      
+
       <h2>Add a component</h2>
 
       <p>The prototype kit has 2 ways to use components. You can either use HTML or a Nunjucks macro.</p>
@@ -26,9 +26,6 @@
       <p>You can copy the HTML or Nunjucks code from each of the components pages on the components section of the service manual.</p>
 
       <p>Explore the <a href="https://service-manual.nhs.uk/design-system">NHS.UK digital service manual</a> for code snippets and guidance on how to use components.</p>
-
-      {% include "how-tos/includes/back-button.html" %}
-
     </div>
 
   </div>

--- a/app/views/how-tos/git.html
+++ b/app/views/how-tos/git.html
@@ -50,7 +50,7 @@
       <pre class="app-pre"><code class="app-code">git init</code></pre>
 
       <img class="app-img-guide" alt="Screenshot of git init" src="/images/git/git-init.png" />
-      
+
       <p>Initialising the repo creates a hidden <strong>.git</strong> folder in your project and is where it stores the internal tracking data .</p>
 
       <h2 id="check-git-status">4. Check Git status</h2>
@@ -109,9 +109,6 @@
         <li><a href="https://try.github.io/levels/1/challenges/1">GitHub tutorial on git</a></li>
         <li><a href="http://think-like-a-git.net/">Advanced git tutorial</a></li>
       </ul>
-
-      {% include "how-tos/includes/back-button.html" %}
-
     </div>
 
   </div>

--- a/app/views/how-tos/includes/back-button.html
+++ b/app/views/how-tos/includes/back-button.html
@@ -1,5 +1,0 @@
-{{ backLink({
-  "href": "/how-tos",
-  "text": "How to guides",
-  "classes": "nhsuk-u-margin-top-7"
-}) }}

--- a/app/views/how-tos/index.html
+++ b/app/views/how-tos/index.html
@@ -88,12 +88,6 @@
         <li><a href="/how-tos/switching-from-govuk-prototype-kit">Switching from the GOV.UK Prototype Kit</a></li>
       </ul>
 
-      {{ backLink({
-        "href": "/",
-        "text": "Back to Home",
-        "classes": "nhsuk-u-margin-top-7"
-      }) }}
-
     </div>
 
   </div>

--- a/app/views/how-tos/making-pages.html
+++ b/app/views/how-tos/making-pages.html
@@ -40,9 +40,6 @@
       <h2>Page templates</h2>
 
       <p>Copy and paste <a href="/page-templates">page templates</a> into your project.</p>
-
-      {% include "how-tos/includes/back-button.html" %}
-
     </div>
 
   </div>

--- a/app/views/how-tos/passing-data-page.html
+++ b/app/views/how-tos/passing-data-page.html
@@ -95,8 +95,6 @@
   ]
 }) &#125;&#125;</code></pre>
 
-      {% include "how-tos/includes/back-button.html" %}
-
     </div>
 
   </div>

--- a/app/views/how-tos/publish-your-prototype-online.html
+++ b/app/views/how-tos/publish-your-prototype-online.html
@@ -20,7 +20,7 @@
         <li>test it with users</li>
       </ul>
       <p>You'll need a hosting service to publish prototypes online.</p>
-      
+
       <h2>Hosting services</h2>
       <p>The NHS.UK prototype kit runs on any hosting service that supports Node.js.</p>
       <p>Your organisation may already use a hosting service for the prototype kit. Check with your digital team about which platform to use.</p>
@@ -31,7 +31,7 @@
       </ul>
       <p>In Railway, you need to set the command to get started. Go to Settings > Deploy and set it to <code class="app-code">npm run start</code>.</p>
       <p>Some hosting services may automatically deploy your prototype every time you merge new changes in the connected GitHub repository. You may be able to enable automatic deploys. If it hasn't automatically update your prototype, you will need to do this manually.</p>
-      
+
       <h2>Setting a password</h2>
       <p>When running the prototype kit online, you must set a password. This is to stop anyone accidentally finding your prototype and mistaking it for a real service.</p>
       <p>To set a password, check your hosting services documentation on how to set "environment variables". (It may have a slightly different name like "config vars" or "variables".)</p>
@@ -50,9 +50,6 @@
         <li><a href="https://catalins.tech/heroku-environment-variables/">How to set environment variables on Heroku, on the Catalin's Tech website</a></li>
         <li><a href="https://docs.railway.app/develop/variables">Variables, on Railway's website</a></li>
       </ul>
-    
-      {% include "how-tos/includes/back-button.html" %}
-
     </div>
 
   </div>

--- a/app/views/how-tos/switching-from-govuk-prototype-kit.html
+++ b/app/views/how-tos/switching-from-govuk-prototype-kit.html
@@ -124,8 +124,6 @@ include "how-tos/includes/breadcrumb.html" %} {% endblock %} {% block content %}
         >NHS digital service manual #prototype-kit Slack channel</a
       >.
     </p>
-
-    {% include "how-tos/includes/back-button.html" %}
   </div>
 </div>
 {% endblock %}

--- a/app/views/how-tos/updating-the-kit.html
+++ b/app/views/how-tos/updating-the-kit.html
@@ -71,9 +71,6 @@
       <h2>Help and support</h2>
 
       <p>If you have any problems, ask a developer on your team (if you have one), <a href="mailto:england.service-manual@nhs.net?subject=NHS.UK prototype kit - Updating the kit">email us</a> or get in touch on the <a href="https://nhs-service-manual.slack.com/messages/CFYL2GDGW" rel="nofollow">NHS digital service manual #prototype-kit Slack channel</a>.</p>
-
-      {% include "how-tos/includes/back-button.html" %}
-
     </div>
 
   </div>

--- a/app/views/install/mac-or-windows.html
+++ b/app/views/install/mac-or-windows.html
@@ -16,7 +16,6 @@
         text: "Get started"
       }
     ],
-
     href: "/install/simple",
     text: "Install guide"
   }) }}

--- a/app/views/install/mac-or-windows.html
+++ b/app/views/install/mac-or-windows.html
@@ -10,10 +10,15 @@
       {
         href: "/",
         text: "Home"
+      },
+      {
+        href: "/install",
+        text: "Get started"
       }
     ],
-    href: "/install",
-    text: "Get started"
+
+    href: "/install/simple",
+    text: "Install guide"
   }) }}
 {% endblock %}
 

--- a/app/views/install/mac-or-windows.html
+++ b/app/views/install/mac-or-windows.html
@@ -55,11 +55,6 @@
 
       </form>
 
-      {{ backLink({
-        "href": "/install",
-        "text": "Back to Install guide"
-      }) }}
-
     </div>
 
   </div>


### PR DESCRIPTION
Previously the NHS Service Manual used to advise having back links at the bottom of pages.

However following community consultation [this was recently changed](https://github.com/nhsuk/nhsuk-service-manual/pull/2034) to instead suggesting having back links at the top in the `beforeContent` block.

This PR removes a few remaining back links at the bottom of pages. Generally these duplicate either a back link or a breadcrumb at the top and so could just be removed but in a couple of places there was nothing at the top so I’ve moved the back link there instead.