### PR TITLE
Merge fieldset options into radios macro

### DIFF
--- a/app/views/examples/branching/index.html
+++ b/app/views/examples/branching/index.html
@@ -24,33 +24,30 @@
 
       <form action="/examples/branching/answer" method="post">
 
-        {% call fieldset({
-          legend: {
-            text: "Do you know your NHS number?",
-            classes: "nhsuk-fieldset__legend--l",
-            isPageHeading: true
-          }
-        }) %}
-
         {{ radios({
-          "idPrefix": "know-nhs-number",
-          "name": "know-nhs-number",
-          "items": [
+          fieldset: {
+            legend: {
+              text: "Do you know your NHS number?",
+              classes: "nhsuk-fieldset__legend--l",
+              isPageHeading: true
+            }
+          },
+          idPrefix: "know-nhs-number",
+          name: "know-nhs-number",
+          items: [
             {
-              "value": "Yes",
-              "text": "Yes"
+              value: "Yes",
+              text: "Yes"
             },
             {
-              "value": "No",
-              "text": "No"
+              value: "No",
+              text: "No"
             }
           ]
         }) }}
 
-        {% endcall %}
-
         {{ button({
-          "text": "Continue"
+          text: "Continue"
         }) }}
 
       </form>

--- a/app/views/install/mac-or-windows.html
+++ b/app/views/install/mac-or-windows.html
@@ -27,34 +27,30 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <form action="/install/mac" method="post">
-
-        {% call fieldset({
-          legend: {
-            text: "What computer are you using?",
-            classes: "nhsuk-fieldset__legend--l",
-            isPageHeading: true
-          }
-        }) %}
-
         {{ radios({
-          "idPrefix": "machine",
-          "name": "machine",
-          "items": [
+          fieldset: {
+            legend: {
+              text: "What computer are you using?",
+              classes: "nhsuk-fieldset__legend--l",
+              isPageHeading: true
+            }
+          },
+          idPrefix: "machine",
+          name: "machine",
+          items: [
             {
-              "value": "Mac",
-              "text": "Mac"
+              value: "Mac",
+              text: "Mac"
             },
             {
-              "value": "Windows",
-              "text": "Windows"
+              value: "Windows",
+              text: "Windows"
             }
           ]
         }) }}
 
-        {% endcall %}
-
         {{ button({
-          "text": "Continue"
+          text: "Continue"
         }) }}
 
       </form>


### PR DESCRIPTION
Just a bit of tidying up - no need to use `call fieldset` here as the options can be specified on the `radio` macro directly.

Also switched the macro keys to not be quoted following recent coding style update.