### PR TITLE
Switch when the 'build' step happens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "nhsuk-prototype-kit",
       "version": "0.1.0",
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.26.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "app.js",
   "scripts": {
     "build": "gulp build",
-    "postinstall": "npm run build",
+    "prestart": "npm run build",
     "start": "node app.js",
     "test": "jest --coverage=true",
     "prewatch": "gulp build",


### PR DESCRIPTION
Currently a build is triggered every time `npm install` is run. This can be considered a bit unexpected, and is an unnecessary step when installing the dependencies just to run code style tests.  It also seems to stop the npm cache working.

Instead, this switches the build to happen before starting the app, in the same way that the build happens before running `npm run watch`.