### PR TITLE
Add Figure component

### DIFF
--- a/app/assets/sass/components/_figure.scss
+++ b/app/assets/sass/components/_figure.scss
@@ -1,0 +1,20 @@
+// ==========================================================================
+// COMPONENTS / Figure
+// ==========================================================================
+//
+// A figure can be used to pair an image such as a diagram with a visible
+// caption.
+
+.nhsuk-figure {
+  margin: 0;
+  @include nhsuk-responsive-margin(5, "bottom");
+}
+
+.nhsuk-figure__image {
+  max-width: 100%;
+  @include nhsuk-responsive-margin(1, "bottom");
+}
+
+.nhsuk-figure__caption {
+  @include nhsuk-typography-responsive(19);
+}

--- a/app/assets/sass/main.scss
+++ b/app/assets/sass/main.scss
@@ -4,6 +4,7 @@
 // Components that are not in the NHS.UK frontend library
 @import 'components/list-border';
 @import 'components/related-nav';
+@import 'components/figure';
 
 ///////////////////////////////////////////
 // Add your custom CSS/Sass styles below...

--- a/app/views/how-tos/build-basic-prototype/index.html
+++ b/app/views/how-tos/build-basic-prototype/index.html
@@ -30,11 +30,10 @@ Our prototype will look a bit like this:
 </p>
 
 
-<figure>
-
-    <p><img style="max-width: 100%;" src="/images/tutorial-overview.png" alt="The first page has the title 'Start page' with the button 'Start now'. This is linked to a second page with the title 'Question 1' and a 'Continue' button. This forks to 2 different pages. 1 is titled 'Ineligible'. 2 is titled Question 2. Question 2 is linked to a page titled 'Check answers'. This links to page 6, titled 'Complete'."></p>
-    <figcaption class="govuk-body">Diagram of 6 pages connected together.</figcaption>
-    </figure>
+<figure class="nhsuk-figure">
+  <img class="nhsuk-figure__image" src="/images/tutorial-overview.png" alt="The first page has the title 'Start page' with the button 'Start now'. This is linked to a second page with the title 'Question 1' and a 'Continue' button. This forks to 2 different pages. 1 is titled 'Ineligible'. 2 is titled Question 2. Question 2 is linked to a page titled 'Check answers'. This links to page 6, titled 'Complete'.">
+  <figcaption class="nhsuk-figure__caption">Diagram of 6 pages connected together.</figcaption>
+</figure>
 
 
 <h2>

--- a/app/views/how-tos/build-basic-prototype/use-components-2.html
+++ b/app/views/how-tos/build-basic-prototype/use-components-2.html
@@ -62,15 +62,13 @@ label: {
 }
 }) &#125;&#125;</code></pre>
 <p>Your page should now look like this:</p>
-<figure>
-  <p>
-    <img
-      src="/images/tutorial-textarea.png"
-      style="max-width: 100%"
-      alt='Web page with the heading "{{exampleTextArea.title}}", a textarea and continue button'
-    />
-  </p>
-  <figcaption class="govuk-body">
+<figure class="nhsuk-figure">
+  <img
+    src="/images/tutorial-textarea.png"
+    class="nhsuk-figure__image"
+    alt='Web page with the heading "{{exampleTextArea.title}}", a textarea and continue button'
+  />
+  <figcaption class="nhsuk-figure__caption">
     Screenshot of how your prototype should look.
   </figcaption>
 </figure>

--- a/app/views/how-tos/build-basic-prototype/use-components.html
+++ b/app/views/how-tos/build-basic-prototype/use-components.html
@@ -101,15 +101,13 @@ set prev = { "title" : "Link your pages together" , "link" :
 }) &#125;&#125;</code></pre>
 
 <p>Your page should now look like this:</p>
-<figure>
-  <p>
-    <img
+<figure class="nhsuk-figure">
+  <img
       src="/images/tutorial-radios.png"
-      style="max-width: 100%"
+      class="nhsuk-figure__image"
       alt='Web page with the heading "Have you had symptoms of magical power in the last 30 days?", 3 radios and a continue button'
     />
-  </p>
-  <figcaption class="govuk-body">
+  <figcaption class="nhsuk-figure__caption">
     Screenshot of how your prototype should look.
   </figcaption>
 </figure>


### PR DESCRIPTION
This makes a few visual tweaks to images with a caption below them.

Changes:

* remove default margin which is causing the caption and image to be inset
* make the caption text regular font size (19px) for increased readability
* increase margin below the the figure

These styles are configured in a new 'Figure' component to make it easier to maintain.

Thanks @michaelgallagher for spotting.

## Screenshots

| Before | After |
| ------ | ----- |
| ![Screenshot 2024-11-04 at 10 03 17](https://github.com/user-attachments/assets/ce288f91-66fd-4a66-bd97-138d6c600f4f) | ![Screenshot 2024-11-04 at 09 59 00](https://github.com/user-attachments/assets/8074bc7a-47ef-4d0e-974c-f1d91c82b88e) |



