### PR TITLE
Style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Use 'NHS.UK' for products that are for delivery teams and not the public (find o
 Use 'NHS England Windows laptops' instructions for people using corporate laptops.
 
 #### NHS.UK prototype kit
-'NHS.UK' is in caps and 'prototype kit' in lower case (except where the NHS.UK is shown as a logo when it is then presented as NHS Prototype kit). Write out in full the first time it is used on a page, then call 'the kit'. Do not use 'prototype kit' if you can.
+'NHS.UK' is in caps and 'prototype kit' in lower case (except where the NHS.UK is shown as a logo when it is then presented as 'NHS Prototype kit'). Write out in full the first time it is used on a page, then call 'the kit'. Do not use 'prototype kit' if you can.
  
 #### terminal
 Lower case. Only use for Mac and Linux instructions. Usually it will be 'the terminal'.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ This repository contains the content and code for the guidance website for the N
 
 For the code for the NHS prototype kit itself, see [nhsuk-prototype-kit on GitHub](https://github.com/nhsuk/nhsuk-prototype-kit).
 
-
 ## Running the website
 
 Start the code by running `npm run watch`.
@@ -13,29 +12,33 @@ Start the code by running `npm run watch`.
 
 If you want to contribute to the NHS.UK prototype kit guidance, then read our [contributing guidelines](CONTRIBUTING.md).
 
-
 ### Style guide
+
 We normally use the [NHS content guide](https://service-manual.nhs.uk/content) for terms. But there are some terms that are only used in the guidance for the kit:
 
-### command line 
-Lower case. Only use for Windows instructions. Nortmally it will be 'the command line'.
+### command line
+
+Lower case. Only use for Windows instructions. Nortmally it will be ‘the command line’.
 
 #### GOV.UK Prototype Kit, GOV.UK Design System and other GOV.UK products
-Title case. 
+
+Title case.
 
 #### NHS, NHS.UK, NHS England
-Use 'NHS.UK' for products that are for delivery teams and not the public (find out more on the [NHS health writing A-Z](https://service-manual.nhs.uk/content/a-to-z-of-nhs-health-writing#N))This includes the NHS.UK prototype kit, NHS.UK design system, NHS.UK service manual or NHS.UK website. 
+
+Use ‘NHS.UK’ for products that are for delivery teams and not the public (find out more on the [NHS health writing A-Z](https://service-manual.nhs.uk/content/a-to-z-of-nhs-health-writing#N))This includes the NHS.UK prototype kit, NHS.UK design system, NHS.UK service manual or NHS.UK website.
 
 #### NHS England laptops
-Use 'NHS England Windows laptops' instructions for people using corporate laptops.
+Use ‘NHS England Windows laptops’ instructions for people using corporate laptops.
 
 #### NHS.UK prototype kit
-'NHS.UK' is in caps and 'prototype kit' in lower case (except where the NHS.UK is shown as a logo when it is then presented as 'NHS Prototype kit'). Write out in full the first time it is used on a page, then call 'the kit'. Do not use 'prototype kit' if you can.
- 
-#### terminal
-Lower case. Only use for Mac and Linux instructions. Usually it will be 'the terminal'.
 
+‘NHS.UK’ is in caps and ‘prototype kit’ in lower case (except where the NHS.UK is shown as a logo when it is then presented as ‘NHS Prototype kit’). Write out in full the first time it is used on a page, then call ’the kit’. Do not use ‘prototype kit’ if you can.
+
+#### terminal
+
+Lower case. Only use for Mac and Linux instructions. Usually it will be ‘the terminal’.
 
 ## Support
 
-The NHS.UK prototype kit guidance website is maintained by NHS England. [Email us](mailto:[england.service-manual@nhs.net](mailto:england.service-manual@nhs.net)), open a [Github issue](https://github.com/nhsuk/nhsuk.service-manual.prototype-kit.docs/issues/new) or get in touch on the [NHS digital service manual Slack workspace](https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE).
+The NHS.UK prototype kit guidance website is maintained by NHS England. [Email us](<mailto:[england.service-manual@nhs.net](mailto:england.service-manual@nhs.net)>), open a [Github issue](https://github.com/nhsuk/nhsuk.service-manual.prototype-kit.docs/issues/new) or get in touch on the [NHS digital service manual Slack workspace](https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE).

--- a/README.md
+++ b/README.md
@@ -13,6 +13,29 @@ Start the code by running `npm run watch`.
 
 If you want to contribute to the NHS.UK prototype kit guidance, then read our [contributing guidelines](CONTRIBUTING.md).
 
+
+### Style guide
+We normally use the [NHS content guide](https://service-manual.nhs.uk/content) for terms. But there are some terms that are only used in the guidance for the kit:
+
+### command line 
+Lower case. Only use for Windows instructions. Nortmally it will be 'the command line'.
+
+#### GOV.UK Prototype Kit, GOV.UK Design System and other GOV.UK products
+Title case. 
+
+#### NHS, NHS.UK, NHS England
+Use 'NHS.UK' for products that are for delivery teams and not the public (find out more on the [NHS health writing A-Z](https://service-manual.nhs.uk/content/a-to-z-of-nhs-health-writing#N))This includes the NHS.UK prototype kit, NHS.UK design system, NHS.UK service manual or NHS.UK website. 
+
+#### NHS England laptops
+Use 'NHS England Windows laptops' instructions for people using corporate laptops.
+
+#### NHS.UK prototype kit
+'NHS.UK' is in caps and 'prototype kit' in lower case (except where the NHS.UK is shown as a logo when it is then presented as NHS Prototype kit). Write out in full the first time it is used on a page, then call 'the kit'. Do not use 'prototype kit' if you can.
+ 
+#### terminal
+Lower case. Only use for Mac and Linux instructions. Usually it will be 'the terminal'.
+
+
 ## Support
 
 The NHS.UK prototype kit guidance website is maintained by NHS England. [Email us](mailto:[england.service-manual@nhs.net](mailto:england.service-manual@nhs.net)), open a [Github issue](https://github.com/nhsuk/nhsuk.service-manual.prototype-kit.docs/issues/new) or get in touch on the [NHS digital service manual Slack workspace](https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ We normally use the [NHS content guide](https://service-manual.nhs.uk/content) f
 
 ### command line
 
-Lower case. Only use for Windows instructions. Nortmally it will be ‘the command line’.
+Lower case. Only use for Windows instructions. Normally it will be ‘the command line’.
 
 #### GOV.UK Prototype Kit, GOV.UK Design System and other GOV.UK products
 


### PR DESCRIPTION
starting point for style guide. 

Things to check:
 * all the points really
 * anything re formatting. I thought this would be a definition list but the health guide A-Z is headings? 
 
Fixes #62 
 
 > ### Style guide
 >
 >We normally use the [NHS content guide](https://service-manual.nhs.uk/content) for terms. But there are some terms that are only used in the guidance for the kit:
 >
 > ### command line
 >
 >Lower case. Only use for Windows instructions. Nortmally it will be ‘the command line’.
 > 
 > #### GOV.UK Prototype Kit, GOV.UK Design System and other GOV.UK products
 >
 > Title case.
 >
 > #### NHS, NHS.UK, NHS England
 >
 > Use ‘NHS.UK’ for products that are for delivery teams and not the public (find out more on the [NHS health writing A-Z](https://service-manual.nhs.uk/content/a-to-z-of-nhs-health-writing#N))This includes the NHS.UK prototype kit, NHS.UK design system, NHS.UK service manual or NHS.UK website.
 >
 > #### NHS England laptops
 > Use ‘NHS England Windows laptops’ instructions for people using corporate laptops.
 >
 > #### NHS.UK prototype kit
 >
 > ‘NHS.UK’ is in caps and ‘prototype kit’ in lower case (except where the NHS.UK is shown as a logo when it is then presented as ‘NHS Prototype kit’). Write out in full the first time it is used on a page, then call ’the kit’. Do not use ‘prototype kit’ if you can.
 >
 > #### terminal
 > 
 > Lower case. Only use for Mac and Linux instructions. Usually it will be ‘the terminal’.

Things I'd like to add:
* anything about file paths - for example do we always need to spell them out as from the top or is it OK to be a bit more loose about them?
* more about the terminal and command prompt stuff, maybe I don't have enough yet to complete that

