### PR TITLE
Fix homepage page title

### DIFF
--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -7,10 +7,6 @@
   <link href="/css/docs.css" rel="stylesheet">
 {% endblock %}
 
-{% block pageTitle %}
-  NHS.UK prototype kit docs
-{% endblock %}
-
 {% block header %}
   {{ header({
     homeHref: "/",


### PR DESCRIPTION
This doesn't need to be set here, as it’s already set in the template. Also doesn't need the word "docs" on the end.