### PR TITLE
Added 'learn when to use the kit' page

### DIFF
--- a/app/views/about.html
+++ b/app/views/about.html
@@ -20,7 +20,7 @@
 
       <p class="nhsuk-lede-text">The NHS.UK prototype kit enables you to make interactive prototypes that will look like NHS services and pages on NHS.UK. The prototypes you make are a great way to show ideas to others and for conducting user research.</p>
 
-      <p>Find out <a href="/why-use">why to use the NHS.UK prototype kit</a>.</p>
+      <p><a href="/learn-when-use-kit">Learn when to use the NHS.UK prototype kit</a>.</p>
 
 
       <h2>Support</h2>

--- a/app/views/about.html
+++ b/app/views/about.html
@@ -20,6 +20,9 @@
 
       <p class="nhsuk-lede-text">The NHS.UK prototype kit enables you to make interactive prototypes that will look like NHS services and pages on NHS.UK. The prototypes you make are a great way to show ideas to others and for conducting user research.</p>
 
+      <p>Find out <a href="/why-use">why to use the NHS.UK prototype kit</a>.</p>
+
+
       <h2>Support</h2>
 
       <p>The NHS.UK prototype kit is maintained by NHS England. If you've got a question or need support you can:</p>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -61,7 +61,7 @@
       <hr class="nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-6">
 
       <div class="nhsuk-u-reading-width">
-        <p class="nhsuk-u-margin-bottom-0">Visit the <a href="https://service-manual.nhs.uk">NHS digital service manual</a> for guidance and examples.</p>
+        <p class="nhsuk-u-margin-bottom-0">Find out <a href="/why-use">why to use the NHS.UK prototype kit</a> and visit the <a href="https://service-manual.nhs.uk">NHS digital service manual</a> for guidance and examples.</p>
       </div>
 
     </div>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -61,7 +61,7 @@
       <hr class="nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-6">
 
       <div class="nhsuk-u-reading-width">
-        <p class="nhsuk-u-margin-bottom-0">Find out <a href="/why-use">why to use the NHS.UK prototype kit</a> and visit the <a href="https://service-manual.nhs.uk">NHS digital service manual</a> for guidance and examples.</p>
+        <p class="nhsuk-u-margin-bottom-0"><a href="/learn-when-use-kit">Learn when to use the NHS.UK prototype kit</a> and visit the <a href="https://service-manual.nhs.uk">NHS digital service manual</a> for guidance and examples.</p>
       </div>
 
     </div>

--- a/app/views/learn-when-use-kit.html
+++ b/app/views/learn-when-use-kit.html
@@ -1,7 +1,7 @@
 {% extends 'layout.html' %}
 
 {% block pageTitle %}
-  Why use the kit - NHS.UK prototype kit
+  Learn when to use the kit - NHS.UK prototype kit
 {% endblock %}
 
 {% block beforeContent %}
@@ -16,7 +16,7 @@
 
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1>Why use the NHS.UK prototype kit</h1>
+      <h1>Learn when to use the NHS.UK prototype kit</h1>
 
       <p class="nhsuk-lede-text">The NHS.UK prototype kit lets you make HTML prototypes of NHS.UK services.</p>
 

--- a/app/views/why-use.html
+++ b/app/views/why-use.html
@@ -1,0 +1,64 @@
+{% extends 'layout.html' %}
+
+{% block pageTitle %}
+  Why use the kit - NHS.UK prototype kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ breadcrumb({
+    href: "/",
+    text: "Home"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+
+    <div class="nhsuk-grid-column-two-thirds">
+
+      <h1>Why use the NHS.UK prototype kit</h1>
+
+      <p class="nhsuk-lede-text">The NHS.UK prototype kit lets you make HTML prototypes of NHS.UK services.</p>
+
+
+      <h2 class="nhsuk-heading-m">When to use the NHS.UK prototype kit</h2>
+
+      <p>This kit lets you make HTML prototypes with the same front-end code as the NHS website. This means that you can:</p>
+
+      <ul class="nhsuk-list nhsuk-list--bullet">
+        <li>create a service that looks and behaves like NHS online services, on mobile and desktop</li>
+        <li>test on the user‘s device and with assistive technology (for example, a screen reader)</li>
+        <li>show different pages based on user input (called '<a href="./how-tos/branching">branching</a>') to test journey flows
+        </li>
+        <li><a href="./how-tos/publish-your-prototype-online">share them by publishing on the web</a></li>
+        <li>make design decisions within the constraints of the web</li>
+        <li>share understanding of design ideas, flows and behaviours with the whole team – including those that use assistive technology</li>
+        <li><a href="./how-tos/git">use common tools like Git and GitHub</a> for collaboration and project history</li>
+      </ul>
+
+      <p>If your service is in the <a href="https://www.gov.uk/service-manual/agile-delivery/how-the-alpha-phase-works">alpha phase</a> or <a href="https://www.gov.uk/service-manual/agile-delivery/how-the-beta-phase-works">beta phase</a> and does not use the NHS.UK prototype kit for testing with users, you may get <a href="https://www.gov.uk/service-manual/design/making-prototypes#when-to-use-prototypes">feedback in your service assessment report to use the kit</a>.</p>
+
+      <h3 class="nhsuk-heading-s">Do not use the NHS.UK prototype kit for real services</h3>
+
+      <p>
+      You must not use prototype code for production. When your service is ready to move into production, the code needs to meet different standards. For example, it needs to be secure and perform well with large volumes of traffic.
+      </p>
+
+
+      <h2 class="nhsuk-heading-m">When to use other prototyping tools</h2>
+      <p>
+       Sometimes you may want to use different tools for prototyping, for example if you:
+        </p>
+
+        <ul class="nhsuk-list nhsuk-list--bullet">
+          <li>want to draw different journeys as a team activity</li>
+          <li>need to make screens with people who are not comfortable using code</li>
+          <li>
+            are designing screens that will not use the same components or patterns as the NHS website, for example clinician services
+          </li>
+         </ul>
+<P>You can get examples of other <a href="https://design-system.service.gov.uk/community/resources-and-tools/">community resources from the GOV.UK Design System</a>. You may need to change these to use NHS.UK branding.</p>
+    </div>
+
+  </div>
+{% endblock %}


### PR DESCRIPTION
Added page based on GOV.UK guidance https://prototype-kit.service.gov.uk/docs/prototyping (and restructured to be about the kit first with notes about other methods later)

## Learn when to use the NHS.UK prototype kit page

![Learn when to use the NHS.UK prototype kit](https://github.com/user-attachments/assets/09aaf472-94f0-441f-8fd8-980092bac2d8)

This links to the govuk design system community resources page as there isn't yet a version for the NHS.

## Links 
Also added link to pages

### Home


<img width="986" alt="Learn when to use the NHS.UK prototype kit and visit the NHS digital service manual for guidance and examples." src="https://github.com/user-attachments/assets/8465f119-8610-438c-b910-808d8ba1d85d">


### About

<img width="707" alt="Learn when to use the NHS.UK prototype kit" src="https://github.com/user-attachments/assets/8fde8588-b4ca-49aa-a8ef-953d71d359fe">


## Things I'm thinking about

1. The fact we can't link to NHS.UK resources yet - hopefully we can swap this out if and when they are available
2. ~The balance between 'why' and 'when' in headers -may need tweaking for example to 'learn when to use the NHS.UK prototype kit'~ Now with 'Learn when to use the NHS.UK prototype kit'
3. Is it 'HTML prototype' (as on the home page and so adopted here), 'code prototype' (as on the govuk website) or something else? Does this need to go into the style guide for the kit as well?
4. There is a bit of repetition between this page and the about page (for example not using this for production code) - this may be fine, but the extreme would even be to make this page part of the about page and have support as its own thing

