### PR TITLE
Add Gitpod config

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,4 @@
+
+tasks:
+  - init: npm install && npm run build
+    command: npm run watch


### PR DESCRIPTION
This adds config for Gitpod, which can then be used for local development or content editing in the browser.

Gitpod seems to already work by default, but by default it runs `npm start` instead of `npm run watch` - the main difference is that `npm run watch` will automatically rebuild CSS and javascript, and will enable browser-sync to automatically refresh the browser when making changes.