### PR TITLE
Update page templates page

### DIFF
--- a/app/views/page-templates.html
+++ b/app/views/page-templates.html
@@ -16,23 +16,23 @@
 
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1>Page templates</h1>
+      <h1 class="nhsuk-heading-xl">Page templates</h1>
 
-      <p>You can find these templates in the <strong>/views/templates</strong> folder.</p>
+      <p>You can find these templates in the <strong>/docs/views/templates</strong> folder within your prototype.</p>
 
-      <p>You can copy and paste the templates in any folder within <strong>/app/views</strong>.</p>
+      <p>To use one, copy and paste it from there into your <strong>/app/views</strong> folder.</p>
 
-      <h2>Content pages</h2>
+      <h2 class="nhsuk-heading-m">Content pages</h2>
 
-      <ul>
+      <ul class="nhsuk-list">
         <li><a href="/templates/blank-nhsuk">Blank NHS.UK</a></li>
         <li><a href="/templates/content-page">Content page</a></li>
         <li><a href="/templates/mini-hub">Mini hub</a></li>
       </ul>
 
-      <h2>Transactional journeys</h2>
+      <h2 class="nhsuk-heading-m">Transactional journeys</h2>
 
-      <ul>
+      <ul class="nhsuk-list">
         <li><a href="/templates/blank-transactional">Blank transactional</a></li>
         <li><a href="/templates/start-page">Start page</a></li>
         <li><a href="/templates/question-page">Question page</a></li>
@@ -40,9 +40,9 @@
         <li><a href="/templates/confirmation-page">Confirmation</a></li>
       </ul>
 
-      <h2>NHS website pages</h2>
+      <h2 class="nhsuk-heading-m">NHS website pages</h2>
 
-      <ul>
+      <ul class="nhsuk-list">
         <li><a href="/templates/nhsuk-homepage">NHS website homepage</a></li>
         <li><a href="/templates/nhsuk-healthaz">Health A to Z</a></li>
         <li><a href="/templates/nhsuk-livewell">Live Well</a></li>


### PR DESCRIPTION
This fixes the description of where the templates are located within the kit, and adds a clearer description of how to use them.

Also removes the bullets from the lists and tweaks the heading sizes.

Fixes #96