### PR TITLE
Rename 'How to guides' as 'Guides'

### DIFF
--- a/app/views/examples/branching/index.html
+++ b/app/views/examples/branching/index.html
@@ -13,7 +13,7 @@
       }
     ],
     href: "/how-tos",
-    text: "How to guides"
+    text: "Guides"
   }) }}
 {% endblock %}
 

--- a/app/views/examples/passing-data/clear-data-success.html
+++ b/app/views/examples/passing-data/clear-data-success.html
@@ -13,7 +13,7 @@
       }
     ],
     href: "/how-tos",
-    text: "How to guides"
+    text: "Guides"
   }) }}
 {% endblock %}
 

--- a/app/views/examples/passing-data/clear-data.html
+++ b/app/views/examples/passing-data/clear-data.html
@@ -13,7 +13,7 @@
       }
     ],
     href: "/how-tos",
-    text: "How to guides"
+    text: "Guides"
   }) }}
 {% endblock %}
 

--- a/app/views/examples/passing-data/passing-data-check-answers.html
+++ b/app/views/examples/passing-data/passing-data-check-answers.html
@@ -13,7 +13,7 @@
       }
     ],
     href: "/how-tos",
-    text: "How to guides"
+    text: "Guides"
   }) }}
 {% endblock %}
 

--- a/app/views/examples/passing-data/passing-data-confirmation.html
+++ b/app/views/examples/passing-data/passing-data-confirmation.html
@@ -13,7 +13,7 @@
       }
     ],
     href: "/how-tos",
-    text: "How to guides"
+    text: "Guides"
   }) }}
 {% endblock %}
 

--- a/app/views/examples/passing-data/passing-data-question-conditions.html
+++ b/app/views/examples/passing-data/passing-data-question-conditions.html
@@ -13,7 +13,7 @@
       }
     ],
     href: "/how-tos",
-    text: "How to guides"
+    text: "Guides"
   }) }}
 {% endblock %}
 

--- a/app/views/examples/passing-data/passing-data-question-contact.html
+++ b/app/views/examples/passing-data/passing-data-question-contact.html
@@ -13,7 +13,7 @@
       }
     ],
     href: "/how-tos",
-    text: "How to guides"
+    text: "Guides"
   }) }}
 {% endblock %}
 

--- a/app/views/examples/passing-data/passing-data-question-name.html
+++ b/app/views/examples/passing-data/passing-data-question-name.html
@@ -13,7 +13,7 @@
       }
     ],
     href: "/how-tos",
-    text: "How to guides"
+    text: "Guides"
   }) }}
 {% endblock %}
 

--- a/app/views/how-tos/branching.html
+++ b/app/views/how-tos/branching.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  How to do branching - NHS.UK prototype kit
+  Branching - NHS.UK prototype kit
 {% endblock %}
 
 {% block beforeContent %}
@@ -13,7 +13,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-three-quarters">
 
-      <h1>How to do branching</h1>
+      <h1>Branching</h1>
 
       <p class="nhsuk-lede-text">You can show a user different pages, depending on how they've answered a question.
 

--- a/app/views/how-tos/build-basic-prototype/_BASE.njk
+++ b/app/views/how-tos/build-basic-prototype/_BASE.njk
@@ -24,7 +24,7 @@
       },
       {
         href: "/how-tos",
-      text: "How to guides"
+      text: "Guides"
       },
       {
         href: "/how-tos/build-basic-prototype/index",

--- a/app/views/how-tos/build-basic-prototype/link-index-page-start-page.html
+++ b/app/views/how-tos/build-basic-prototype/link-index-page-start-page.html
@@ -19,9 +19,9 @@ makePrototype %}
   </li>
 </ol>
 <p>
-  You can now find out
+  You can now find out how to
   <a href="/how-tos/publish-your-prototype-online"
-    >how to publish your prototype online</a
+    >publish your prototype online</a
   >, so you can share it with your team or do user research.
 </p>
 

--- a/app/views/how-tos/components.html
+++ b/app/views/how-tos/components.html
@@ -1,7 +1,7 @@
 {% extends 'layout.html' %}
 
 {% block pageTitle %}
-  How to use components - NHS.UK prototype kit
+  Using components - NHS.UK prototype kit
 {% endblock %}
 
 {% block beforeContent %}
@@ -14,7 +14,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        How to use components
+        Using components
       </h1>
 
       <p class="nhsuk-lede-text">Components are reusable parts of the user interface, like buttons, text inputs and checkboxes.</p>

--- a/app/views/how-tos/git.html
+++ b/app/views/how-tos/git.html
@@ -1,7 +1,7 @@
 {% extends 'layout.html' %}
 
 {% block pageTitle %}
-  How to setup Git - NHS.UK prototype kit
+  Setting up Git - NHS.UK prototype kit
 {% endblock %}
 
 {% block beforeContent %}
@@ -14,7 +14,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        How to setup Git
+        Setting up Git
       </h1>
 
       <p>Git is a type of version control software that tracks changes in your code. For example, when you edit a file, git can help you determine exactly what changed, who changed it, and why.</p>

--- a/app/views/how-tos/includes/breadcrumb.html
+++ b/app/views/how-tos/includes/breadcrumb.html
@@ -6,5 +6,5 @@
     }
   ],
   href: "/how-tos",
-  text: "How to guides"
+  text: "Guides"
 }) }}

--- a/app/views/how-tos/index.html
+++ b/app/views/how-tos/index.html
@@ -16,7 +16,7 @@
 
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1>How to guides</h1>
+      <h1>Guides</h1>
 
       <p class="nhsuk-lede-text">These guides will show you how to use the prototype kit, from creating a simple page to building complex user journeys.</p>
 

--- a/app/views/how-tos/making-pages.html
+++ b/app/views/how-tos/making-pages.html
@@ -1,7 +1,7 @@
 {% extends 'layout.html' %}
 
 {% block pageTitle %}
-  How to make pages - NHS.UK prototype kit
+  Making pages - NHS.UK prototype kit
 {% endblock %}
 
 {% block beforeContent %}
@@ -14,7 +14,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        How to make pages
+        Making pages
       </h1>
 
       <p class="nhsuk-lede-text">Use your HTML text editor to make pages.</p>

--- a/app/views/how-tos/passing-data-page.html
+++ b/app/views/how-tos/passing-data-page.html
@@ -1,7 +1,7 @@
 {% extends 'layout.html' %}
 
 {% block pageTitle %}
-  How to pass data page to page - NHS.UK prototype kit
+  Passing data page to page - NHS.UK prototype kit
 {% endblock %}
 
 {% block beforeContent %}
@@ -13,7 +13,7 @@
 
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1>How to pass data page to page</h1>
+      <h1>Passing data page to page</h1>
 
       <p class="nhsuk-lede-text">You may want to use or display data a user has entered over a few screens.</p>
 

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -42,7 +42,7 @@
           {{ card({
             "href": "/how-tos",
             "clickable": "true",
-            "heading": "How to guides",
+            "heading": "Guides",
             "headingClasses": "nhsuk-heading-m",
             "description": "Learn to create pages, use components, add data and more"
           }) }}

--- a/app/views/install/check-it-works.html
+++ b/app/views/install/check-it-works.html
@@ -65,8 +65,8 @@
       <p>The kit is now installed. Congratulations!</p>
 
       <h2>Getting going</h2>
-      <p><a href="/how-tos/build-basic-prototype/index">Build a basic prototype</a> or view other <a href="/how-tos/index">how to guides</a>.</p>
-      
+      <p><a href="/how-tos/build-basic-prototype/index">Build a basic prototype</a> or view other <a href="/how-tos/index">guides</a>.</p>
+
       {% block pagination %}
       {% endblock %}
 


### PR DESCRIPTION
This is a proposal - would be interested to see what others think! Rationale below.

---
This renames the 'How to guides' as simply 'Guides'.

This is because:

* 'How to guides' is an awkward phrase to read, as you. might initially assume the third word is a verb (like "How to code" and then have to re-evaluate it as a noun phrase
* It’s longer than it needs to be, and we might want to have a navigation bar at some point, in which case 'Guides' would be a lot shorter

In addition, some of the guides themselves (which had a mixture of forms) have been renamed to no longer include 'How to'. This also means the link text on the index page now matches the titles when you click through.

They all now start with a verb (although a mix of tenses).

The changes are:

* How to setup Git -> Setting up Git
* How to use components -> Using components
* How to do branching -> Branching
* How to make pages -> Making pages
* How to pass data page to page -> Passing data page to page

The other guide titles are unchanged:

* Build a basic prototype using the NHS.UK prototype kit
* Adding CSS, JavaScript and Images
* Updating the kit
* Switching from the GOV.UK prototype kit

The breadcrumb is also changed from "How to guides" to just "Guides"