### PR TITLE
Remove unused CSS

### DIFF
--- a/app/assets/sass/docs.scss
+++ b/app/assets/sass/docs.scss
@@ -2,20 +2,6 @@
 @import 'node_modules/nhsuk-frontend/packages/nhsuk';
 
 // ==========================================================================
-// FRONTEND STYLE ADJUSTMENTS
-// ==========================================================================
-
-// Body background white
-.nhsuk-body-white {
-  background-color: $color_nhsuk-white;
-}
-
-// Body background grey
-.nhsuk-body-grey {
-  background-color: $color_nhsuk-grey-5;
-}
-
-// ==========================================================================
 // PROTOTYPE SPECIFIC STYLES
 // ==========================================================================
 


### PR DESCRIPTION
`.nhsuk-body-white` and `.nhsuk-body-grey` aren't being used anywhere on the NHS Prototype kit docs website, and can be removed.