### PR TITLE
Show answers page and let users change answers fixed to reflect nunjucks defaults

### DIFF
--- a/app/views/how-tos/build-basic-prototype/let-user-change-answers.html
+++ b/app/views/how-tos/build-basic-prototype/let-user-change-answers.html
@@ -10,16 +10,16 @@ page" , "link" : "show-users-answers" } %} {% extends
 </p>
 <ol class="nhsuk-list nhsuk-list--number">
   <li>
-    In the <code class="language-markup">&lt;a&gt;</code> tag under
-    <code class="language-markup">{{ data['how-many-balls'] }}</code>, change
-    the href attribute from <code class="language-markup">#</code> to
-    <code class="language-markup">/{{exampleRadios.url}}</code>
+    Find the value
+    <code class="language-markup">data['{{exampleRadios.legend}}']</code>, then change the
+    the <code class="language-markup">href</code> value from <code class="language-markup">'#'</code> to
+    <code class="language-markup">'/{{exampleRadios.url}}'</code>
   </li>
   <li>
-    In the <code class="language-markup">&lt;a&gt;</code> tag under
-    <code class="language-markup">{{ data['most-impressive-trick'] }}</code>,
-    change the href attribute from <code class="language-markup">#</code> to
-    <code class="language-markup">/{{exampleTextArea.url}}</code>
+    Find the value
+    <code class="language-markup">data['{{exampleTextArea.legend}}']</code>, then change the
+    the <code class="language-markup">href</code> value from <code class="language-markup">'#'</code> to
+    <code class="language-markup">'/{{exampleTextArea.url}}'</code>
   </li>
 </ol>
 <p>
@@ -82,8 +82,8 @@ page" , "link" : "show-users-answers" } %} {% extends
   <code class="language-markup">app/views</code> folder.
 </p>
 <p>
-  Add
-  <code class="language-markup">value: data['{{exampleRadios.legend}}']</code>
+  Go to  <code class="language-markup">id: "example",</code> and add a new line
+  <code class="language-markup">value: data['{{exampleRadios.legend}}'],</code>
   like this:
 </p>
 
@@ -91,13 +91,13 @@ page" , "link" : "show-users-answers" } %} {% extends
    textarea({
     name: "example",
     id: "example",
+    value: data['details'],
     label: {
       text: "Tell us your symptoms of magical powers",
       classes: "nhsuk-label--l",
       isPageHeading: true
-    },
-    value: data['details']
-  }) 
+    }
+  })
 
   &#125;&#125;</code></pre>
 

--- a/app/views/how-tos/build-basic-prototype/show-users-answers.html
+++ b/app/views/how-tos/build-basic-prototype/show-users-answers.html
@@ -118,7 +118,7 @@ question 2" , "link" : "use-components-2" } %} {% extends
             actions: {
               items: [
                 {
-                  href: "/magical-powers",
+                  href: "#",
                   text: "Change",
                   visuallyHiddenText: "magical power symptoms in the last 30 days"
                 }
@@ -135,7 +135,7 @@ question 2" , "link" : "use-components-2" } %} {% extends
             actions: {
               items: [
                 {
-                  href: "/details",
+                  href: "#",
                   text: "Change",
                   visuallyHiddenText: "details of symptoms"
                 }

--- a/app/views/how-tos/build-basic-prototype/show-users-answers.html
+++ b/app/views/how-tos/build-basic-prototype/show-users-answers.html
@@ -16,15 +16,15 @@ question 2" , "link" : "use-components-2" } %} {% extends
     your <code class="language-markup">app/views</code> folder.
   </li>
   <li>
-    Find the <code class="language-markup">&lt;dt&gt;</code> tag that contains
+    Find the <code class="language-markup">key</code> that contains
     the text 'NHS number'.
   </li>
   <li>Change 'NHS number' to '{{exampleRadios.summary}}'.</li>
   <li>
-    In the <code class="language-markup">&lt;dd&gt;</code> tag on the next line,
+    In <code class="language-markup">value</code> on the next line,
     change '485 777 3456' to
     <code class="language-markup"
-      >&#123;&#123; data['{{exampleRadios.legend}}'] &#125;&#125;</code
+      >data['{{exampleRadios.legend}}']</code
     >.
   </li>
 </ol>
@@ -33,16 +33,8 @@ question 2" , "link" : "use-components-2" } %} {% extends
   the <code class="language-markup">name</code> attribute from the
   <code class="language-markup">&lt;input&gt;</code> on the question page.
 </p>
-<p>Update the screen reader text – change this</p>
-<pre
-  tabindex="0"
-><code class="language-markup" >&lt;span class="govuk-visually-hidden"&gt; name&lt;/span&gt;
-</code></pre>
-<p>to</p>
-<pre
-  tabindex="0"
-><code class="language-markup" >&lt;span class="govuk-visually-hidden"&gt; {{exampleRadios.summary | lower }}&lt;/span&gt;
-</code></pre>
+<p>Update the screen reader text – on the next line <code class="language-markup">visuallyHiddenText</code> change
+ 'NHS number' to '{{exampleRadios.summary | lower }}'.
 <p>
   Screen readers will read this out but it will not appear on the page. Without
   this hidden text, screen reader users would just hear “Change” and not know
@@ -51,28 +43,22 @@ question 2" , "link" : "use-components-2" } %} {% extends
 <h2 id="show-the-answer-to-question-2">Show the answer to question 2</h2>
 <ol class="nhsuk-list nhsuk-list--number">
   <li>
-    Find the <code class="language-markup">&lt;dt&gt;</code> tag that contains
+    Find the <code class="language-markup">key</code> that contains
     the text 'Name'.
   </li>
   <li>Change 'Name' to '{{exampleTextArea.summary}}'.</li>
   <li>
-    In the <code class="language-markup">&lt;dd&gt;</code> tag on the next line,
+    In the <code class="language-markup">value</code> on the next line,
     change 'Kevin Francis' to
-    <code class="language-markup"
-      >&#123;&#123; data['{{exampleTextArea.legend}}'] &#125;&#125;</code
+    <code class="language-markup">
+      data['{{exampleTextArea.legend}}']</code
     >.
   </li>
+  <li>
+    On the next line <code class="language-markup">visuallyHiddenText</code> change
+     'name' to '{{exampleTextArea.summary | lower }}'
+  </li>
 </ol>
-<p>Change</p>
-<pre
-  tabindex="0"
-><code class="language-markup" >&lt;span class="govuk-visually-hidden"&gt; name&lt;/span&gt;
-</code></pre>
-<p>to</p>
-<pre
-  tabindex="0"
-><code class="language-markup" >&lt;span class="govuk-visually-hidden"&gt; {{exampleTextArea.legend | lower}}&lt;/span&gt;
-</code></pre>
 <p>
   <a href="http://localhost:3000/{{exampleStart.url}}"
     >Go to http://localhost:3000/{{exampleStart.url}}</a
@@ -88,12 +74,10 @@ question 2" , "link" : "use-components-2" } %} {% extends
 </p>
 <ol class="nhsuk-list nhsuk-list--number">
   <li>
-    Find and delete the whole
-    <code class="language-markup">&lt;div&gt;</code> that starts with
-    <code class="language-markup"
-      >&lt;div class="govuk-summary-list__row"&gt;</code
-    >
-    and contains 'Contact information'.
+    Find the
+    <code class="language-markup">,</code> (comma) after the details you have changed, and delete this and everything up to the <code class="language-markup">]</code> (square bracket).
+
+
   </li>
   <li>
     Find and delete the whole
@@ -113,15 +97,15 @@ question 2" , "link" : "use-components-2" } %} {% extends
 
   {{ '<div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
-  
+
       <h1 class="nhsuk-heading-l">
         Check your answers before sending your application
       </h1>
-  
+
       <h2 class="nhsuk-heading-m">
         Personal details
       </h2>
-  
+
       {{ summaryList({
         rows: [
           {
@@ -160,27 +144,27 @@ question 2" , "link" : "use-components-2" } %} {% extends
           }
         ]
       }) }}
-  
-  
+
+
       <h2 class="nhsuk-heading-m">
         Now send your application
       </h2>
-  
+
       <p>
         By submitting this notification you are confirming that, to the best of your knowledge, the details you are providing are correct.
       </p>
-  
+
       <p>
         Your details with be sent to Rose Medical Practice to begin your registration.
       </p>
-  
+
       <a href="/confirmation-page" class="nhsuk-button">
         Accept and send registration
       </a>
-  
+
     </div>
   </div>' | escape }}
-  
+
 </code></pre>
 
 {% endblock %}


### PR DESCRIPTION
This has meant a lot of reworking the page as the original was html rather than nunjucks code. I'm still a bit nervous about explaining how to delete bits of an array but the worked example is there at least. 

| Before | After |
| -- | -- |
|  ![original version with HTML examples](https://github.com/user-attachments/assets/ea46dbba-679f-43dd-b43c-9ffaaa5d302d) | ![example with changed code to nunjucks](https://github.com/user-attachments/assets/80813986-4c4d-4c74-afbf-607ff01b8237) | 
