### PR TITLE
fixed broken links and aligned with advanced install page

### DIFF
--- a/app/views/how-tos/switching-from-govuk-prototype-kit.html
+++ b/app/views/how-tos/switching-from-govuk-prototype-kit.html
@@ -21,10 +21,10 @@ include "how-tos/includes/breadcrumb.html" %} {% endblock %} {% block content %}
 
     <p>When you are installing and running your prototype:</p>
 
-    {{ list({ title: "Do", type: "tick", items: [ { item: '<a
-      href="/install/download-zip"
-      >download the kit using the zip file or Github</a
-    >' }, { item: 'start your local server by entering in the terminal:
+    {{ list({ title: "Do", type: "tick", items: [ { item: 'get the kit either by <a
+      href="https://prototype-kit.service-manual.nhs.uk/download"
+      >downloading it as a zip</a
+    > or by <a href="https://github.com/nhsuk/nhsuk-prototype-kit">cloning or downloading a copy from GitHub</a>' }, { item: 'start your local server by entering in the terminal:
     <pre
       class="app-pre"
     ><code class="language-markup">npm run watch</code></pre>


### PR DESCRIPTION
Fixed broken link and added direct links to the prototype zip and repository (mirroring what is on the advanced install page). 

This may need review in the future to see if we should just link to the advanced install page or if this is better.