### PR TITLE
Added notes on updating the prototype kit

### DIFF
--- a/app/views/how-tos/switching-from-govuk-prototype-kit.html
+++ b/app/views/how-tos/switching-from-govuk-prototype-kit.html
@@ -99,6 +99,10 @@ include "how-tos/includes/breadcrumb.html" %} {% endblock %} {% block content %}
       for more details.
     </p>
 
+    <h2 class="nhsuk-heading-m">Updating your prototype </h2>
+
+    <p>If you want to update your prototype to the latest version, you will need to download the latest version of the kit and copy some files into your prototype - you can find out what to do in <a href="/how-tos/updating-the-kit">Updating the kit</a>.</p>
+
     <h2>Help and support</h2>
 
     <p>If you have any problems:</p>

--- a/app/views/how-tos/switching-from-govuk-prototype-kit.html
+++ b/app/views/how-tos/switching-from-govuk-prototype-kit.html
@@ -101,7 +101,7 @@ include "how-tos/includes/breadcrumb.html" %} {% endblock %} {% block content %}
 
     <h2 class="nhsuk-heading-m">Updating your prototype </h2>
 
-    <p>If you want to update your prototype to the latest version, you will need to download the latest version of the kit and copy some files into your prototype - you can find out what to do in <a href="/how-tos/updating-the-kit">Updating the kit</a>.</p>
+    <p>If you want to update your prototype to the latest version, you will need to download the latest version of the kit and copy some files into your prototype. Go to the <a href="/how-tos/updating-the-kit">guide on updating the kit</a> for more details.</p>
 
     <h2>Help and support</h2>
 


### PR DESCRIPTION
Added section

> ## Updating your prototype
> 
> If you want to update your prototype to the latest version, you will need to download the latest version of the kit and copy some files into your prototype. Go to the [guide on updating the kit](/how-tos/updating-the-kit) for more details.

Still deciding if this could be a part of the installing and using and if it should be a dos/don't, but at the very least this catches something that is dramatically different.