### PR TITLE
Add main nav

### DIFF
--- a/app/assets/sass/main.scss
+++ b/app/assets/sass/main.scss
@@ -7,3 +7,10 @@
 ///////////////////////////////////////////
 // Add your custom CSS/Sass styles below...
 ///////////////////////////////////////////
+
+// This is a temporary fix to remove the 'Home' link in
+// the primary navigation which is added Header primary nav.
+// Should be able to remove this after the next NHS Frontend update.
+.nhsuk-header__navigation-item--home {
+  display: none;
+}

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -13,7 +13,22 @@
     ariaLabel: "NHS Prototype Kit homepage",
     service: {
       name: serviceName
-    }
+    },
+    showNav: "true",
+    primaryLinks: [
+      {
+        label: "Get started",
+        url: "/install"
+      },
+      {
+        label: "Guides",
+        url: "/how-tos"
+      },
+      {
+        label: "Support",
+        url: "/support"
+      }
+    ]
   }) }}
 {% endblock %}
 


### PR DESCRIPTION
This adds a "primary nav" with 3 items:

* Get started
* Guides
* Support

"Contribute" could be added when #148 is merged.

I’ve not included "Page templates" as that page feels less valuable longer-term (eg if the NHS website templates get moved to a plugin or something).

Adding the primary nav possibly means that some of the breadcrumbs could be removed or shortened (eg the "Home" breadcrumb link on Support feels a bit odd now?), but the Service Manual website has both, so maybe it’s fine?

There’s no "current section" indicator for now, but we can adopt that when it gets added to the header in the next major release of NHS frontend (hopefully).

![homepage-with-nav](https://github.com/user-attachments/assets/29f5606c-7094-4f9f-8352-f843f80f40a7)

Part of #93 
