### PR TITLE
Changed the pages based on feedback

### DIFF
--- a/app/views/how-tos/build-basic-prototype/branching.html
+++ b/app/views/how-tos/build-basic-prototype/branching.html
@@ -32,7 +32,7 @@ their answers" , "link" : "let-user-change-answers" } %} {% extends
     <p>
       Make an
       <code class="language-markup">{{exampleIneligible.url}}.html</code> page
-      by copying <code class="language-markup">content.html</code> from
+      by copying <code class="language-markup">content-page.html</code> from
       <code class="language-markup">docs/views/templates</code> to
       <code class="language-markup">app/views</code>.
     </p>

--- a/app/views/how-tos/build-basic-prototype/link-pages-together.html
+++ b/app/views/how-tos/build-basic-prototype/link-pages-together.html
@@ -130,9 +130,9 @@ components from the design system" , "link" : "use-components" } %} {% set prev
     and select <strong>Accept and send registration</strong> to check the button works.
   </p>
 
-  {{ warningCallout({
-    heading: "Other links in your pages",
-    HTML: "<p>Your example pages include back links that go back to the template start page. We are not changing them in this tutorial. If you want, you can try and change the links in the back links by using the <a href='https://service-manual.nhs.uk/design-system/components/back-link'>back link component guidance</a>.</p>"
+
+  {{ insetText({
+    HTML: "<p>The back links in your pages don't go to the correct places yet. If you want, you can try and change the links in the back links by using the <a href='https://service-manual.nhs.uk/design-system/components/back-link'>back link component guidance</a>.</p>"
   }) }}
 
   {% endblock %}

--- a/app/views/how-tos/build-basic-prototype/link-pages-together.html
+++ b/app/views/how-tos/build-basic-prototype/link-pages-together.html
@@ -12,6 +12,8 @@ components from the design system" , "link" : "use-components" } %} {% set prev
       user inputs data)
     </li>
   </ul>
+
+
   <h2 id="link-your-start-page-to-question-1">
     Link your start page to question 1
   </h2>
@@ -127,6 +129,11 @@ components from the design system" , "link" : "use-components" } %} {% set prev
     >
     and select <strong>Accept and send registration</strong> to check the button works.
   </p>
+
+  {{ warningCallout({
+    heading: "Other links in your pages",
+    HTML: "<p>Your example pages include back links that go back to the template start page. We are not changing them in this tutorial. If you want, you can try and change the links in the back links by using the <a href='https://service-manual.nhs.uk/design-system/components/back-link'>back link component guidance</a>.</p>"
+  }) }}
 
   {% endblock %}
 </div>

--- a/app/views/how-tos/build-basic-prototype/link-pages-together.html
+++ b/app/views/how-tos/build-basic-prototype/link-pages-together.html
@@ -132,7 +132,7 @@ components from the design system" , "link" : "use-components" } %} {% set prev
 
 
   {{ insetText({
-    HTML: "<p>The back links in your pages don't go to the correct places yet. If you want, you can try and change the links in the back links by using the <a href='https://service-manual.nhs.uk/design-system/components/back-link'>back link component guidance</a>.</p>"
+    HTML: "<p>The back links in your pages do not go to the correct places yet. If you want, you can try and change the links in the back links by using the <a href='https://service-manual.nhs.uk/design-system/components/back-link'>back link component guidance</a>.</p>"
   }) }}
 
   {% endblock %}

--- a/app/views/how-tos/build-basic-prototype/use-components-2.html
+++ b/app/views/how-tos/build-basic-prototype/use-components-2.html
@@ -30,7 +30,7 @@ design system" , "link" : "use-components" } %} {% extends
 
 <h3 id="customise-the-example-code">Customise the example code</h3>
 <ol class="nhsuk-list nhsuk-list--number">
-  <li>Delete <code class="language-markup">&#123;% from "govuk/components/textarea/macro.njk" import govukTextarea %}</code>.</li>
+  <li>Delete <code class="language-markup">&#123;% from "textarea/macro.njk" import textarea %}</code>.</li>
   <li>
     Under <code class="language-markup">label</code>, change
     <code class="language-markup">text</code> from "Can you provide more

--- a/app/views/how-tos/build-basic-prototype/use-components.html
+++ b/app/views/how-tos/build-basic-prototype/use-components.html
@@ -65,6 +65,10 @@ set prev = { "title" : "Link your pages together" , "link" :
     <code class="language-markup">hintHtml</code> and add "For example, things moving when you have strong feelings or hearing
       someone's thoughts".
   </li>
+  <li>
+    In the <code class="language-markup">items: &#123; text:</code> areas delete all the text after "Yes" and "No"
+  
+  </li>
 </ol>
 <p>Your component code should now look like this:</p>
 
@@ -74,7 +78,7 @@ set prev = { "title" : "Link your pages together" , "link" :
   name: "example-hints",
   fieldset: {
     legend: {
-      text: "Do you know your NHS number?",
+      text: "{{ exampleRadios.title }}"" ,
       classes: "nhsuk-fieldset__legend--l",
       isPageHeading: true
     }
@@ -85,11 +89,11 @@ set prev = { "title" : "Link your pages together" , "link" :
   items: [
   {
     value: "yes",
-    text: "Yes, I know my NHS number"
+    text: "Yes"
   },
   {
     value: "no",
-    text: "No, I do not know my NHS number"
+    text: "No"
   },
   {
     value: "not sure",


### PR DESCRIPTION
Fixed:

Typo on gov template https://prototype-kit.service-manual.nhs.uk/how-tos/build-basic-prototype/use-components-2

| Before | After | 
| --- | -- |
| <img width="675" alt='Delete {% from "govuk/components/textarea/macro.njk" import govukTextarea %}.' src="https://github.com/user-attachments/assets/d232a10b-eb3f-4c22-a840-ba9781cb230c"> | <img width="695" alt='Delete {% from "textarea/macro.njk" import textarea %}.' src="https://github.com/user-attachments/assets/37fa14bb-3be6-4ac9-9c94-00c126c41f03"> | 


Typo with content page naming on https://prototype-kit.service-manual.nhs.uk/how-tos/build-basic-prototype/branching

| Before | After | 
| --- | -- |
| <img width="721" alt="Create an ineligible page - Make an ineligible.html page by copying content.html from docs/views/templates to app/views." src="https://github.com/user-attachments/assets/7740c237-da23-4023-abbd-8fd21a5960b3"> | <img width="416" alt="Create an ineligible page - Make an ineligible.html page by copying content-page.html from docs/views/templates to app/views." src="https://github.com/user-attachments/assets/ebec1202-0184-4d47-bcb9-6ce4217693d7"> | 

Missing details on changing the components text to Yes and No https://prototype-kit.service-manual.nhs.uk/how-tos/build-basic-prototype/use-components

| Before | After | 
| --- | -- |
| ![Use components from the design system](https://github.com/user-attachments/assets/d4ea6ff2-d1da-4dfd-9fec-8045e56bccd8) | ![Use components from the design system with details about changing text](https://github.com/user-attachments/assets/c9476e6b-03c5-4a62-8d92-135c0a1031dd) | 

Added note about back links not being in this tutorial - this seems too much to add as an entire thing (and ideally the default link can be changed?)  https://prototype-kit.service-manual.nhs.uk/how-tos/build-basic-prototype/link-pages-together

| Before | After | 
| --- | -- |
| !['Link your pages together' page](https://github.com/user-attachments/assets/869ed49b-2bcc-4266-a0ac-79858970c9e3) | !['Link your pages together' page with new area 'Other links in your pages - Your example pages include back links that go back to the template start page. We are not changing them in this tutorial. If you want, you can try and change the links in the back links by using the back link component guidance.' ](https://github.com/user-attachments/assets/856fc652-def7-4493-873d-4c58d4bde364) |






