### PR TITLE
Added filters page and link from how-tos

### DIFF
--- a/app/filters.js
+++ b/app/filters.js
@@ -1,20 +1,5 @@
 module.exports = function (env) { /* eslint-disable-line func-names,no-unused-vars */
   const filters = {};
 
-  filters.sentenceCase = function (input){
-    // check the input
-    // blank: do not do anything
-    if (!input) return ''; 
-     // not text: do not do anything
-    if (typeof input !== 'string') return input;
-    // is a string/text
-    // text: change first character to uppercase and put it back in the string
-    return input.charAt(0).toUpperCase() + input.slice(1); 
-  }; 
-
-  filters.shorten = function(str, count) {
-    return str.slice(0, count || 5);
-};
-
   return filters;
 };

--- a/app/filters.js
+++ b/app/filters.js
@@ -1,5 +1,20 @@
 module.exports = function (env) { /* eslint-disable-line func-names,no-unused-vars */
   const filters = {};
 
+  filters.sentenceCase = function (input){
+    // check the input
+    // blank: do not do anything
+    if (!input) return ''; 
+     // not text: do not do anything
+    if (typeof input !== 'string') return input;
+    // is a string/text
+    // text: change first character to uppercase and put it back in the string
+    return input.charAt(0).toUpperCase() + input.slice(1); 
+  }; 
+
+  filters.shorten = function(str, count) {
+    return str.slice(0, count || 5);
+};
+
   return filters;
 };

--- a/app/views/how-tos/filters.html
+++ b/app/views/how-tos/filters.html
@@ -14,7 +14,7 @@ Filters - NHS prototype kit
   <div class="nhsuk-grid-column-three-quarters">
     <h1>Filters</h1>
     <p class="nhsuk-lede-text">
-      Change how answers are shown.
+      Change how text is displayed.
       </p>
 
     <p>

--- a/app/views/how-tos/filters.html
+++ b/app/views/how-tos/filters.html
@@ -52,15 +52,42 @@ Filters - NHS prototype kit
       Add your own filters to the <code>filters.js</code> file. Filters are
       written in JavaScript. 
     </p>
-    <p>Creating filters may need help from a developer, but if someone else has made one you can paste them in to your filters.js file.</p>
-    <p>For example this filter will let you change the first letter of an answer to upper case, for example from "a test" to "A test". </p>
-
-
-    <h2 class="nhsuk-heading-m">Add a filter</h2>
-    <p>
-      Add your own filters to the <code>filters.js</code> file. Filters are
-      written in JavaScript. 
+    <p>Creating filters may need help from a developer, but if someone else has made one you can paste them in to your filters.js file. 
+      
+      </p>
+      <h3 class="nhsuk-heading-s">Use examples that are already in your filters.js file</h3>
+      <p>
+      You can see some examples in the file.</p>
+    <p>For example, find and copy this code in your file:
     </p>
+
+    <pre
+  class="app-pre"
+>
+<code class="app-code">filters.sayHi = function(name,tone) {
+      return (tone == 'formal' ? 'Greetings' : 'Hi') + ' ' + name + '!'
+    }</code></pre>
+
+<p>Then find this line (usually line 39)
+  <pre
+  class="app-pre"
+>
+<code class="app-code">------------------------------------------------------------------ */</code></pre>
+
+</p>
+
+<p>Then paste the code you just copied and save your changes. You will be able to the filter on on a page: </p>
+
+<pre
+class="app-pre"
+><code class="app-code">{{ "{{ 'Joel' | greetings('formal') }}" | escape }} </code></pre>
+  
+  
+  <p>It will show as 'Greetings, Joel!'. </p>
+
+
+  <h3 class="nhsuk-heading-s">Use examples from other NHS prototypes</h3>
+
     <p>If someone else using the NHS prototype kit has made a filter, you can paste them in to your file.</p>
     <p>For example this filter will let you change text to sentence case, for example from "a test" to "A test". </p>
 
@@ -78,34 +105,15 @@ Filters - NHS prototype kit
   return input.charAt(0).toUpperCase() + input.slice(1); 
 };</code></pre>
 
-<p>Go to <code>filters.js</code> and add it after <code>const filters = {};</code> and before <code>};</code>  </p>
-</pre>
-    <p>Check that your file looks like this:</p>
-    <pre 
-    <pre
-      class="app-pre"
-    ><code class="app-code">module.exports = function (env) { /* eslint-disable-line func-names,no-unused-vars */
-  const filters = {};
-
-  filters.sentenceCase = function (input){
-    // check the input
-    // blank: do not do anything
-    if (!input) return ''; 
-     // not text: do not do anything
-    if (typeof input !== 'string') return input;
-    // is a string/text
-    // text: change first character to uppercase and put it back in the string
-    return input.charAt(0).toUpperCase() + input.slice(1); 
-  }; 
-};</code></pre>
-    <p>Then use it on a page like this:</p>
+  
+  <p>When you have added it to your filters.js file, you can use it on a page like this:</p>
     <pre
       class="app-pre"
     ><code class="app-code">{{ "{{ data['name'] | sentenceCase }}" | escape }} </code></pre>
    
 
  
-    <h3 class="nhsuk-heading-s">Use HTML in a Nunjucks filter</h3>
+    <h3 class="nhsuk-heading-s">Make a filter that uses HTML</h3>
     <p>If you want to use HTML in a filter, write the filter:</p>
     <pre
       class="app-pre"

--- a/app/views/how-tos/filters.html
+++ b/app/views/how-tos/filters.html
@@ -14,7 +14,7 @@ Filters - NHS prototype kit
   <div class="nhsuk-grid-column-three-quarters">
     <h1>Filters</h1>
     <p class="nhsuk-lede-text">
-      Change how answers and dates are shown.
+      Change how answers are shown.
       </p>
 
     {{ insetText({ html: '
@@ -32,7 +32,7 @@ Filters - NHS prototype kit
     <ul class="nshuk-list nhsuk-list-bullet">
       <li>use existing Nunjucks filters</li>
       <li>create a Nunjucks filter</li>
-      <li>use filters from other projects</li>
+      <li>use filters from other projects (recommended for advanced users only)</li>
     </ul>
     <h2 class="nhsuk-heading-m">Use existing Nunjucks filters</h2>
     <p>
@@ -92,50 +92,17 @@ Filters - NHS prototype kit
       class="app-pre"
     ><code class="app-code">{{"{{ data['name'] | upper |  bold | safe }}" | escape }}</code></pre>
 
-    <h2 class="nhsuk-heading-m">Use filters from other projects</h2>
+    <h2 class="nhsuk-heading-m">Use filters from other projects (recommended for advanced users only)</h2>
     <p>
-      You can import filters from other projects like the <a href="https://x-govuk.github.io/govuk-prototype-filters/get-started/">x-govuk Prototype Filters
-      project</a>. If you want to do this, you will need to install it first - follow the instructions for 'Using with earlier versions of the Prototype Kit'.
+      If you are confident with Javascript, you can install and import filters from other projects like the X-GOVUK Prototype Filters
+      project.
+      </p>
+      <p>You will need to change your <code>filters.js</code> file using the the instructions for 'Using with earlier versions of the Prototype Kit'.
     </p>
-
-    <p>For example, you can <a href="https://x-govuk.github.io/govuk-prototype-filters/get-started/">use existing x-govuk date filters</a> to add dates that will change in your prototype. </p>
-
-    <h3 class="nhsuk-heading-s" id="show-and-format-a-date">Show and format a date</h3>
-
-    <p>To show today's date when a user submits their application:</p>
-<pre
-      class="app-pre"
-    ><code class="app-code">You submitted your application on {{'{{ "today" | govukDate }}' | safe }} .
-</code></pre>
-<p>To display a time:</p>
-<pre
-      class="app-pre"
-    ><code class="app-code">You signed into your account at {{'{{ "now" | govukTime }}' | escape }}.
-</code></pre>
-<h3 class="nhsuk-heading-s" id="change-the-format-of-a-date">Change the format of a date</h3>
-<p>You can change how dates appear, so that you display the name of the month instead of a number. </p>
-<p>To show the month 'March':</p>
-<pre
-      class="app-pre"
-    ><code class="app-code">{{'{{ 3 | monthName }}' | escape }}
-</code></pre>
-<p>To shorten (or 'truncate') the month 'March' to 'Mar':</p>
-<pre
-      class="app-pre"
-    ><code class="app-code">{{'{{ 3 | monthName("truncate") }}' | escape }}
-</code></pre>
-<h3 class="nhsuk-heading-s" id="show-how-many-days-have-passed">Show how many days have passed</h3>
-<p>To show how long it's been since a user submitted their application:</p>
-<pre class="app-pre" ><code class="app-code">{{"{% set dateSubmitted = '2023-09-18' %}"}}
-{{"<p>You submitted your application {{ dateSubmitted | daysAgo | plural('day') }} ago</p>" | escape }}
-</code></pre>
-<h3 class="nhsuk-heading-s" id="show-when-a-user-is-eligible">Show when a user is eligible</h3>
-<p>You can use filters to show when someone is eligible to use your service. For example, if they must be 18 to apply:</p>
-<pre
-      class="app-pre"
-    ><code class="app-code">{{"{% set dateOfBirth = '2010-09-18' %}"}}
-{{"<p>You can apply for a juggling licence on {{ dateOfBirth | duration(18, 'years') | govukDate }}</p>" | escape }}
-</code></pre>
+    <p>
+      <a href="https://x-govuk.github.io/govuk-prototype-filters/get-started/">Go to the X-GOV.UK GOV.UK Prototype filters project</a>
+    </p>
+   
   </div>
 </div>
 {% endblock %}

--- a/app/views/how-tos/filters.html
+++ b/app/views/how-tos/filters.html
@@ -1,0 +1,135 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+Use filters to change how answers appear - NHS prototype kit
+{% endblock %}
+
+{% block beforeContent %}
+  {% include "how-tos/includes/breadcrumb.html" %}
+{% endblock %}
+
+{% block content %}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-three-quarters">
+    <h1>Use filters to change how answers appear</h1>
+
+    {{ insetText({ html: '
+    <p>
+      To use filters, you need to know how to
+      <a href="passing-data-page">pass data from page to page</a>.
+    </p>
+    ' })}}
+
+    <p>
+      The kit stores data from all answers that users give in a prototype, so
+      that you can use or show the answers later. To change the format of how
+      these answers appear, you can apply filters. You can:</p>
+
+    <ul class="nshuk-list nhsuk-list-bullet">
+      <li>use existing Nunjucks filters</li>
+      <li>create a Nunjucks filter</li>
+      <li>import filters from other projects</li>
+    </ul>
+    <h2 class="nhsuk-heading-m">Use existing Nunjucks filters</h2>
+    <p>
+      You can
+      <a
+        href="https://mozilla.github.io/nunjucks/templating.html#builtin-filters"
+        >use existing Nunjucks filters</a
+      >
+      in the kit. For example, you can use the Nunjucks
+      <code>upper</code> filter to change the format of text to upper case:
+    </p>
+
+    <pre
+      class="app-pre"
+    ><code class="app-code">&#123;{ data['name'] | upper }}</code></pre>
+
+    <h2 class="nhsuk-heading-m">Create a Nunjucks filter</h2>
+    <p>
+      Add your own filters to the <code>filters.js</code> file. Filters are
+      written in JavaScript.
+    </p>
+    <pre
+      class="app-pre"
+    ><code class="app-code">module.exports = function (env) { /* eslint-disable-line func-names,no-unused-vars */
+  const filters = {};
+
+  filters.uppercase = function(content) {
+    return content.toUpperCase()
+  }
+  return filters;
+};</code>
+</pre>
+    <p>Then use it on a page like this:</p>
+    <pre
+      class="app-pre"
+    ><code class="app-code">&#123;{ data['name'] | uppercase }&#125;</code></pre>
+
+    <h3 class="nhsuk-heading-s">Use HTML in a Nunjucks filter</h3>
+    <p>If you want to use HTML in a filter, write the filter:</p>
+    <pre
+      class="app-pre"
+    ><code class="app-code">{{ " filters.bold = function (content) {
+  return '<strong>' + content + '</strong>';
+  // remember to use 'safe' after to get the HTML formatting
+}" | escape }} </code></pre>
+    <p>Then use it on a page with the extra filter <code>safe</code>:</p>
+    <pre
+      class="app-pre"
+    ><code class="app-code">{{"{{ data['name'] | bold | safe }}" | escape }}</code></pre>
+    <p>
+      Safe makes the filter format the HTML and not just show the code
+      <code>{{"<strong></strong>" | escape }}</code>.
+    </p>
+
+    <p>You can also use these filters together:</p>
+    <pre
+      class="app-pre"
+    ><code class="app-code">{{"{{ data['name'] | upper |  bold | safe }}" | escape }}</code></pre>
+
+    <h2 class="nhsuk-heading-m">Import filters from other projects</h2>
+    <p>
+      You can import filters from other projects like the <a href="https://x-govuk.github.io/govuk-prototype-filters/get-started/">x-govuk Prototype Filters
+      project</a>. If you want to do this, you will need to install it first - follow the instructions for 'Using with earlier versions of the Prototype Kit'.
+    </p>
+
+    <p>For example, you can <a href="https://x-govuk.github.io/govuk-prototype-filters/get-started/">use existing x-govuk date filters</a> to add dates that will change in your prototype. </p>
+<p>To show today's date when a user submits their application:</p>
+<pre
+      class="app-pre"
+    ><code class="app-code">You submitted your application on {{'{{ "today" | govukDate }}' | safe }} .
+</code></pre>
+<p>To display a time:</p>
+<pre
+      class="app-pre"
+    ><code class="app-code">You signed into your account at {{'{{ "now" | govukTime }}' | escape }}.
+</code></pre>
+<h3 class="nhsuk-heading-s" id="change-the-format-of-a-date">Change the format of a date</h3>
+<p>You can change how dates appear, so that you display the name of the month instead of a number. </p>
+<p>To show the month 'March':</p>
+<pre
+      class="app-pre"
+    ><code class="app-code">{{'{{ 3 | monthName }}' | escape }}
+</code></pre>
+<p>To shorten (or 'truncate') the month 'March' to 'Mar':</p>
+<pre
+      class="app-pre"
+    ><code class="app-code">{{'{{ 3 | monthName("truncate") }}' | escape }}
+</code></pre>
+<h3 class="nhsuk-heading-s" id="show-how-many-days-have-passed">Show how many days have passed</h3>
+<p>To show how long it's been since a user submitted their application:</p>
+<pre class="app-pre" ><code class="app-code">{{"{% set dateSubmitted = '2023-09-18' %}"}}
+{{"<p>You submitted your application {{ dateSubmitted | daysAgo | plural('day') }} ago</p>" | escape }}
+</code></pre>
+<h3 class="nhsuk-heading-s" id="show-when-a-user-is-eligible">Show when a user is eligible</h3>
+<p>You can use filters to show when someone is eligible to use your service. For example, if they must be 18 to apply:</p>
+<pre
+      class="app-pre"
+    ><code class="app-code">{{"{% set dateOfBirth = '2010-09-18' %}"}}
+{{"<p>You can apply for a juggling licence on {{ dateOfBirth | duration(18, 'years') | govukDate }}</p>" | escape }}
+</code></pre>
+  </div>
+</div>
+{% endblock %}

--- a/app/views/how-tos/filters.html
+++ b/app/views/how-tos/filters.html
@@ -59,7 +59,7 @@ Filters - NHS prototype kit
     ><code class="app-code">module.exports = function (env) { /* eslint-disable-line func-names,no-unused-vars */
   const filters = {};
 
-  filters.uppercase = function(content) {
+  filters.uppercase = function (content) {
     return content.toUpperCase()
   }
   return filters;
@@ -74,7 +74,7 @@ Filters - NHS prototype kit
     <p>If you want to use HTML in a filter, write the filter:</p>
     <pre
       class="app-pre"
-    ><code class="app-code">{{ " filters.bold = function (content) {
+    ><code class="app-code">{{"filters.bold = function (content) {
   return '<strong>' + content + '</strong>';
   // remember to use the 'safe' filter afterwards to get the HTML formatting
 }" | escape }} </code></pre>
@@ -83,7 +83,7 @@ Filters - NHS prototype kit
       class="app-pre"
     ><code class="app-code">{{"{{ data['name'] | bold | safe }}" | escape }}</code></pre>
     <p>
-      Safe makes the filter format the HTML and not just show the code
+      Using <code>safe</code> makes the text show with the HTML formatting and not just the code
       <code>{{"<strong></strong>" | escape }}</code>.
     </p>
 

--- a/app/views/how-tos/filters.html
+++ b/app/views/how-tos/filters.html
@@ -90,7 +90,7 @@ Filters - NHS prototype kit
     <p>You can also use these filters together:</p>
     <pre
       class="app-pre"
-    ><code class="app-code">{{"{{ data['name'] | upper |  bold | safe }}" | escape }}</code></pre>
+    ><code class="app-code">{{ "{{ data['name'] | upper | bold | safe }}" | escape }}</code></pre>
 
     <h2 class="nhsuk-heading-m">Use filters from other projects (recommended for advanced users only)</h2>
     <p>

--- a/app/views/how-tos/filters.html
+++ b/app/views/how-tos/filters.html
@@ -17,12 +17,10 @@ Filters - NHS prototype kit
       Change how answers are shown.
       </p>
 
-    {{ insetText({ html: '
     <p>
       To use filters, you need to know how to
       <a href="passing-data-page">pass data from page to page</a>.
     </p>
-    ' })}}
 
     <p>
       The kit stores data from all answers that users give in a prototype, so
@@ -31,7 +29,7 @@ Filters - NHS prototype kit
 
     <ul class="nshuk-list nhsuk-list-bullet">
       <li>use existing Nunjucks filters</li>
-      <li>create a Nunjucks filter</li>
+      <li>add a filter</li>
       <li>use filters from other projects (recommended for advanced users only)</li>
     </ul>
     <h2 class="nhsuk-heading-m">Use existing Nunjucks filters</h2>
@@ -49,27 +47,64 @@ Filters - NHS prototype kit
       class="app-pre"
     ><code class="app-code">{{ "{{data['name'] | upper }}" | escape }}</code></pre>
 
-    <h2 class="nhsuk-heading-m">Create a Nunjucks filter</h2>
+    <h2 class="nhsuk-heading-m">Add a filter</h2>
     <p>
       Add your own filters to the <code>filters.js</code> file. Filters are
-      written in JavaScript.
+      written in JavaScript. 
     </p>
+    <p>Creating filters may need help from a developer, but if someone else has made one you can paste them in to your filters.js file.</p>
+    <p>For example this filter will let you change the first letter of an answer to upper case, for example from "a test" to "A test". </p>
+
+
+    <h2 class="nhsuk-heading-m">Add a filter</h2>
+    <p>
+      Add your own filters to the <code>filters.js</code> file. Filters are
+      written in JavaScript. 
+    </p>
+    <p>If someone else using the NHS prototype kit has made a filter, you can paste them in to your file.</p>
+    <p>For example this filter will let you change text to sentence case, for example from "a test" to "A test". </p>
+
+    <pre
+      class="app-pre"
+    >
+<code class="app-code">filters.sentenceCase = function (input){
+  // check the input
+  // blank: do not do anything
+  if (!input) return ''; 
+   // not text: do not do anything
+  if (typeof input !== 'string') return input;
+  // is a string/text
+  // text: change first character to uppercase and put it back in the string
+  return input.charAt(0).toUpperCase() + input.slice(1); 
+};</code></pre>
+
+<p>Go to <code>filters.js</code> and add it after <code>const filters = {};</code> and before <code>};</code>  </p>
+</pre>
+    <p>Check that your file looks like this:</p>
+    <pre 
     <pre
       class="app-pre"
     ><code class="app-code">module.exports = function (env) { /* eslint-disable-line func-names,no-unused-vars */
   const filters = {};
 
-  filters.uppercase = function (content) {
-    return content.toUpperCase()
-  }
-  return filters;
-};</code>
-</pre>
+  filters.sentenceCase = function (input){
+    // check the input
+    // blank: do not do anything
+    if (!input) return ''; 
+     // not text: do not do anything
+    if (typeof input !== 'string') return input;
+    // is a string/text
+    // text: change first character to uppercase and put it back in the string
+    return input.charAt(0).toUpperCase() + input.slice(1); 
+  }; 
+};</code></pre>
     <p>Then use it on a page like this:</p>
     <pre
       class="app-pre"
-    ><code class="app-code">&#123;{ data['name'] | uppercase }&#125;</code></pre>
+    ><code class="app-code">{{ "{{ data['name'] | sentenceCase }}" | escape }} </code></pre>
+   
 
+ 
     <h3 class="nhsuk-heading-s">Use HTML in a Nunjucks filter</h3>
     <p>If you want to use HTML in a filter, write the filter:</p>
     <pre
@@ -94,10 +129,28 @@ Filters - NHS prototype kit
 
     <h2 class="nhsuk-heading-m">Use filters from other projects (recommended for advanced users only)</h2>
     <p>
-      If you are confident with Javascript, you can install and import filters from other projects like the X-GOVUK Prototype Filters
-      project.
+      If you are confident with Javascript, you can get filters from other places. 
       </p>
-      <p>You will need to change your <code>filters.js</code> file using the instructions for 'Using with earlier versions of the Prototype Kit'.
+
+  
+         <p>If your filters you are trying to use start with 'add Filter' (for example the <a href="https://mozilla.github.io/nunjucks/api.html#custom-filters">Custom Filters in the Nunjucks documentation</a>), you will need to change them to work in the NHS prototype kit.
+          </p><p>
+          For example, if you have a filter like this:</p>
+          <pre
+          class="app-pre"
+        ><code class="app-code">env.addFilter('shorten', function(str, count) {
+          return str.slice(0, count || 5);
+      }); </code></pre>
+       
+      <p>change <code>env.addFilter('shorten, function',</code> to <code>filters.shorten = function</code> and remove <code>)</code> at the end.</p>
+      <p>The code will then look like this:</p>
+      <pre
+      class="app-pre"
+    ><code class="app-code">filters.shorten = function(str, count) {
+      return str.slice(0, count || 5);
+  };</code></pre>
+
+      <p>One project with a lot of tools is the XGOV-UK Prototype Filters plugin. If you want to use this plugin, you will need to change your <code>filters.js</code> file using the instructions for 'Using with earlier versions of the Prototype Kit'.
     </p>
     <p>
       <a href="https://x-govuk.github.io/govuk-prototype-filters/get-started/">Go to the X-GOV.UK GOV.UK Prototype filters project</a>

--- a/app/views/how-tos/filters.html
+++ b/app/views/how-tos/filters.html
@@ -76,7 +76,7 @@ Filters - NHS prototype kit
       class="app-pre"
     ><code class="app-code">{{ " filters.bold = function (content) {
   return '<strong>' + content + '</strong>';
-  // remember to use 'safe' after to get the HTML formatting
+  // remember to use the 'safe' filter afterwards to get the HTML formatting
 }" | escape }} </code></pre>
     <p>Then use it on a page with the extra filter <code>safe</code>:</p>
     <pre

--- a/app/views/how-tos/filters.html
+++ b/app/views/how-tos/filters.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-Use filters to change how answers appear - NHS prototype kit
+Filters - NHS prototype kit
 {% endblock %}
 
 {% block beforeContent %}
@@ -12,7 +12,10 @@ Use filters to change how answers appear - NHS prototype kit
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-three-quarters">
-    <h1>Use filters to change how answers appear</h1>
+    <h1>Filters</h1>
+    <p class="nhsuk-lede-text">
+      Change how answers and dates are shown.
+      </p>
 
     {{ insetText({ html: '
     <p>
@@ -29,7 +32,7 @@ Use filters to change how answers appear - NHS prototype kit
     <ul class="nshuk-list nhsuk-list-bullet">
       <li>use existing Nunjucks filters</li>
       <li>create a Nunjucks filter</li>
-      <li>import filters from other projects</li>
+      <li>use filters from other projects</li>
     </ul>
     <h2 class="nhsuk-heading-m">Use existing Nunjucks filters</h2>
     <p>
@@ -89,14 +92,17 @@ Use filters to change how answers appear - NHS prototype kit
       class="app-pre"
     ><code class="app-code">{{"{{ data['name'] | upper |  bold | safe }}" | escape }}</code></pre>
 
-    <h2 class="nhsuk-heading-m">Import filters from other projects</h2>
+    <h2 class="nhsuk-heading-m">Use filters from other projects</h2>
     <p>
       You can import filters from other projects like the <a href="https://x-govuk.github.io/govuk-prototype-filters/get-started/">x-govuk Prototype Filters
       project</a>. If you want to do this, you will need to install it first - follow the instructions for 'Using with earlier versions of the Prototype Kit'.
     </p>
 
     <p>For example, you can <a href="https://x-govuk.github.io/govuk-prototype-filters/get-started/">use existing x-govuk date filters</a> to add dates that will change in your prototype. </p>
-<p>To show today's date when a user submits their application:</p>
+
+    <h3 class="nhsuk-heading-s" id="show-and-format-a-date">Show and format a date</h3>
+
+    <p>To show today's date when a user submits their application:</p>
 <pre
       class="app-pre"
     ><code class="app-code">You submitted your application on {{'{{ "today" | govukDate }}' | safe }} .

--- a/app/views/how-tos/filters.html
+++ b/app/views/how-tos/filters.html
@@ -47,7 +47,7 @@ Filters - NHS prototype kit
 
     <pre
       class="app-pre"
-    ><code class="app-code">&#123;{ data['name'] | upper }}</code></pre>
+    ><code class="app-code">{{ "{{data['name'] | upper }}" | escape }}</code></pre>
 
     <h2 class="nhsuk-heading-m">Create a Nunjucks filter</h2>
     <p>
@@ -97,7 +97,7 @@ Filters - NHS prototype kit
       If you are confident with Javascript, you can install and import filters from other projects like the X-GOVUK Prototype Filters
       project.
       </p>
-      <p>You will need to change your <code>filters.js</code> file using the the instructions for 'Using with earlier versions of the Prototype Kit'.
+      <p>You will need to change your <code>filters.js</code> file using the instructions for 'Using with earlier versions of the Prototype Kit'.
     </p>
     <p>
       <a href="https://x-govuk.github.io/govuk-prototype-filters/get-started/">Go to the X-GOV.UK GOV.UK Prototype filters project</a>

--- a/app/views/how-tos/filters.html
+++ b/app/views/how-tos/filters.html
@@ -86,10 +86,9 @@ class="app-pre"
   <p>It will show as 'Greetings, Joel!'. </p>
 
 
-  <h3 class="nhsuk-heading-s">Use examples from other NHS prototypes</h3>
+  <h3 class="nhsuk-heading-s">Make a filter that changes some text to sentence case</h3>
 
-    <p>If someone else using the NHS prototype kit has made a filter, you can paste them in to your file.</p>
-    <p>For example this filter will let you change text to sentence case, for example from "a test" to "A test". </p>
+    <p>This filter will let you change text to sentence case, for example from "a test" to "A test". </p>
 
     <pre
       class="app-pre"

--- a/app/views/how-tos/index.html
+++ b/app/views/how-tos/index.html
@@ -91,6 +91,8 @@
         <li><a href="/how-tos/components">Using components</a></li>
         <li><a href="/how-tos/passing-data-page">Passing data page to page</a></li>
         <li><a href="/how-tos/branching">Branching</a> – show a different page based on user input</li>
+        <li><a href="/how-tos/filters">Use filters to change how answers appear</a></li>
+
       </ul>
 
         <h2 class="nhsuk-heading-s">Share your prototype</h2>

--- a/app/views/how-tos/index.html
+++ b/app/views/how-tos/index.html
@@ -91,7 +91,7 @@
         <li><a href="/how-tos/components">Using components</a></li>
         <li><a href="/how-tos/passing-data-page">Passing data page to page</a></li>
         <li><a href="/how-tos/branching">Branching</a> – show a different page based on user input</li>
-        <li><a href="/how-tos/filters">Use filters to change how answers appear</a></li>
+        <li><a href="/how-tos/filters">Filters</a> - change how answers and dates are shown</li>
 
       </ul>
 

--- a/app/views/how-tos/index.html
+++ b/app/views/how-tos/index.html
@@ -91,7 +91,7 @@
         <li><a href="/how-tos/components">Using components</a></li>
         <li><a href="/how-tos/passing-data-page">Passing data page to page</a></li>
         <li><a href="/how-tos/branching">Branching</a> – show a different page based on user input</li>
-        <li><a href="/how-tos/filters">Filters</a> - change how answers and dates are shown</li>
+        <li><a href="/how-tos/filters">Filters</a> - change how answers are shown</li>
 
       </ul>
 

--- a/app/views/how-tos/index.html
+++ b/app/views/how-tos/index.html
@@ -91,7 +91,7 @@
         <li><a href="/how-tos/components">Using components</a></li>
         <li><a href="/how-tos/passing-data-page">Passing data page to page</a></li>
         <li><a href="/how-tos/branching">Branching</a> – show a different page based on user input</li>
-        <li><a href="/how-tos/filters">Filters</a> - change how answers are shown</li>
+        <li><a href="/how-tos/filters">Filters</a> - change how text is displayed</li>
 
       </ul>
 


### PR DESCRIPTION
Filters page that:
- adapts the govuk prototype kit guidance for using or making filters https://prototype-kit.service.gov.uk/docs/filters and adapts to an earlier version of the kit (particularly for formatting html in filters)
- includes the guidance for dates using xgovuk filters https://prototype-kit.service.gov.uk/docs/date-filters by merging it into the same page

I have tried running this all locally and it seems to work.

## Section in how-tos

<img width="520" alt="section in how-tos" src="https://github.com/user-attachments/assets/d0f8ec42-a372-4833-88b5-659218f516b2">


## Filters page

![page for filters ](https://github.com/user-attachments/assets/2551ad99-e5c9-4a1b-b3d2-e5731e28bf56)


This page may be running long but i am positioning it for now as a way to understand filters. It could be that this gets split, however I also wonder if this shows that the filters part of the kit needs to get updated to make it in line with the current govuk kit.
