### PR TITLE
Fixed typo (thanks Dave for picking up)

### DIFF
--- a/app/views/how-tos/build-basic-prototype/let-user-change-answers.html
+++ b/app/views/how-tos/build-basic-prototype/let-user-change-answers.html
@@ -82,16 +82,16 @@ page" , "link" : "show-users-answers" } %} {% extends
   <code class="language-markup">app/views</code> folder.
 </p>
 <p>
-  Go to  <code class="language-markup">id: "example",</code> and add a new line
-  <code class="language-markup">value: data['{{exampleRadios.legend}}'],</code>
+  Go to  <code class="language-markup">id: "{{exampleTextArea.legend}}",</code> and add a new line
+  <code class="language-markup">value: data['{{exampleTextArea.legend}}'],</code>
   like this:
 </p>
 
 <pre class="app-pre"><code class="language-markup" >&#123;&#123;
    textarea({
-    name: "example",
-    id: "example",
-    value: data['details'],
+    name: "{{exampleTextArea.legend}}",
+    id: "{{exampleTextArea.legend}}",
+    value: data['{{exampleTextArea.legend}}'],
     label: {
       text: "Tell us your symptoms of magical powers",
       classes: "nhsuk-label--l",


### PR DESCRIPTION
Reported by Dave King:

> I noticed there might be an error in the section 'Show the user's answer in question 2' section on the 'Let the user change their answers' page. The guide says that that you need to add a new line value: data['magical-powers'], but I believe this should be value: data['details'] ? I also think that the example code isn't right as it shows the textarea id as being "example" but it was set in a previous step as "details". Hope this helps :)


Corrected page to be: https://prototype-kit.service-manual.nhs.uk/how-tos/build-basic-prototype/let-user-change-answers

| Before | After | 
| -- | --|
| ![data magical powers](https://github.com/user-attachments/assets/f5449f6a-45f0-47dc-876e-24f2c73d00d0) | ![data details ](https://github.com/user-attachments/assets/bf07169d-0720-4bd5-8488-616d4262a104) | 
| ![2 examples of 'example ](https://github.com/user-attachments/assets/5e657fc2-cb15-4a52-91e9-c9a088ba5c81)  | ![2 examples of 'details'](https://github.com/user-attachments/assets/4b493859-5488-4c9f-b15b-e809fc5a2320) | 

