### PR TITLE
Add "Contribute" page to nav

### DIFF
--- a/app/assets/sass/components/_header.scss
+++ b/app/assets/sass/components/_header.scss
@@ -1,0 +1,5 @@
+// This modifier overrides the default behaviour which is to
+// justify the items in the nav when there are 4 or more.
+.app-header--left-aligned .nhsuk-header__navigation-list {
+  justify-content: initial;
+}

--- a/app/assets/sass/docs.scss
+++ b/app/assets/sass/docs.scss
@@ -1,5 +1,6 @@
 // NHS.UK frontend library
 @import 'node_modules/nhsuk-frontend/packages/nhsuk';
+@import 'components/header';
 
 // ==========================================================================
 // PROTOTYPE SPECIFIC STYLES

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -25,6 +25,10 @@
         url: "/how-tos"
       },
       {
+        label: "Contribute",
+        url: "/contribute"
+      },
+      {
         label: "Support",
         url: "/support"
       }

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -9,6 +9,7 @@
 
 {% block header %}
   {{ header({
+    classes: "app-header--left-aligned",
     homeHref: "/",
     ariaLabel: "NHS Prototype Kit homepage",
     service: {


### PR DESCRIPTION
Adds the new 'Contribute' page from #148 to the main nav.

Also adds a temporary CSS modifier to stop the nav from being justified now that there's 4 items (which looks odd).

## Screenshots

### Before 

<img width="988" alt="Before - with no Contribute item" src="https://github.com/user-attachments/assets/f5fbb3fc-3882-4736-a7e6-0c068b85745c">

### After

<img width="987" alt="Before - with Contribute item" src="https://github.com/user-attachments/assets/c85cfc0c-7f9f-42e6-8a2e-e490797590eb">
