### PR TITLE
Remove contribute link from footer

### DIFF
--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -45,10 +45,6 @@
         URL: "/about"
       },
       {
-        label: "Contribute",
-        URL: "/contribute"
-      },
-      {
         label: "Support",
         URL: "/support"
       },


### PR DESCRIPTION
Not sure we need this in the footer now that it’s in the header.