### PR TITLE
Updated links to templates based on v5.2 change

### DIFF
--- a/app/views/how-tos/build-basic-prototype/branching.html
+++ b/app/views/how-tos/build-basic-prototype/branching.html
@@ -33,7 +33,7 @@ their answers" , "link" : "let-user-change-answers" } %} {% extends
       Make an
       <code class="language-markup">{{exampleIneligible.url}}.html</code> page
       by copying <code class="language-markup">content-page.html</code> from
-      <code class="language-markup">docs/views/templates</code> to
+      <code class="language-markup">lib/example-templates</code> to
       <code class="language-markup">app/views</code>.
     </p>
   </li>

--- a/app/views/how-tos/build-basic-prototype/create-pages.html
+++ b/app/views/how-tos/build-basic-prototype/create-pages.html
@@ -7,7 +7,7 @@ extends 'how-tos/build-basic-prototype/_BASE.njk' %} {% block makePrototype %}
 <h3 id="create-a-start-page">Create a start page</h3>
 <p>
   Copy the <code class="language-markup">{{exampleStart.url}}.html</code> file
-  from <code class="language-markup">docs/views/templates</code> to
+  from <code class="language-markup">lib/example-templates</code> to
   <code class="language-markup">app/views</code>.
 </p>
 <p>
@@ -52,7 +52,7 @@ extends 'how-tos/build-basic-prototype/_BASE.njk' %} {% block makePrototype %}
 <p>
   Make 2 copies of the
   <code class="language-markup">question-page.html</code> file from
-  <code class="language-markup">docs/views/templates</code> to
+  <code class="language-markup">lib/example-templates</code> to
   <code class="language-markup">app/views</code>.
 </p>
 <p>Rename the 2 file copies to:</p>
@@ -91,7 +91,7 @@ extends 'how-tos/build-basic-prototype/_BASE.njk' %} {% block makePrototype %}
 <p>
   Copy the
   <code class="language-markup">{{exampleCheckAnswers.url}}.html</code> file
-  from <code class="language-markup">docs/views/templates</code> to
+  from <code class="language-markup">lib/example-templates</code> to
   <code class="language-markup">app/views</code>.
 </p>
 <p>
@@ -106,7 +106,7 @@ extends 'how-tos/build-basic-prototype/_BASE.njk' %} {% block makePrototype %}
 <p>
   Copy the
   <code class="language-markup">{{exampleConfirmation.url}}.html</code> file
-  from <code class="language-markup">docs/views/templates</code> to
+  from <code class="language-markup">lib/example-templates</code> to
   <code class="language-markup">app/views</code>.
 </p>
 <p>

--- a/app/views/how-tos/build-basic-prototype/index.html
+++ b/app/views/how-tos/build-basic-prototype/index.html
@@ -18,7 +18,7 @@ This tutorial shows you how to prototype a fictional "{{exampleServiceName}}" se
   <li>show a confirmation page</li>
 </ul>
 <p>
-It will take about an hour to finish this tutorial, after you install the prototype kit.
+It will take about an hour to finish this tutorial, after you install the prototype kit. 
 </p>
 
 <p>

--- a/app/views/how-tos/build-basic-prototype/open-prototype-in-editor.html
+++ b/app/views/how-tos/build-basic-prototype/open-prototype-in-editor.html
@@ -24,10 +24,6 @@
     <code class="language-markup">routes.js</code> is for advanced logic – for
     example, if a user should go to one page or another based on their answers (we'll cover this later)
   </li>
-  <li>
-    <code class="language-markup">/docs/views/templates</code> has template
-    pages for you to copy into your prototype
-  </li>
 </ul>
 
 {% endblock %}

--- a/app/views/page-templates.html
+++ b/app/views/page-templates.html
@@ -18,7 +18,7 @@
 
       <h1 class="nhsuk-heading-xl">Page templates</h1>
 
-      <p>You can find some example templates for pages in the <strong>/docs/views/templates</strong> folder within your prototype. These include:</p>
+      <p>You can find some example templates for pages in the <strong>/lib/example-templates</strong> folder within your prototype. These include:</p>
 
       <ul>
         <li>content pages</li>


### PR DESCRIPTION
The latest release of the kit included a change to move templates into the lib folder

https://github.com/nhsuk/nhsuk-prototype-kit/pull/409

this now means that some pages link to /docs/views/templates when it now is /lib/example-templates/

These pages are:

https://prototype-kit.service-manual.nhs.uk/how-tos/build-basic-prototype/open-prototype-in-editor
https://prototype-kit.service-manual.nhs.uk/how-tos/build-basic-prototype/create-pages (removed link entirely)
https://prototype-kit.service-manual.nhs.uk/how-tos/build-basic-prototype/branching
https://prototype-kit.service-manual.nhs.uk/page-templates  