### PR TITLE
Update example templates folder reference

### DIFF
--- a/app/views/how-tos/branching.html
+++ b/app/views/how-tos/branching.html
@@ -19,10 +19,6 @@
 
       <p><a href="/examples/branching">You can see an example here</a></p>
 
-      <p>The code for the example can be found in:</p>
-
-      <pre class="app-pre"><code class="app-code">/documentation_routes.js<br>docs/views/examples/branching</code></pre>
-
     </div>
   </div>
 {% endblock %}

--- a/app/views/how-tos/build-basic-prototype/branching.html
+++ b/app/views/how-tos/build-basic-prototype/branching.html
@@ -33,7 +33,7 @@ their answers" , "link" : "let-user-change-answers" } %} {% extends
       Make an
       <code class="language-markup">{{exampleIneligible.url}}.html</code> page
       by copying <code class="language-markup">content-page.html</code> from
-      <code class="language-markup">docs/views/templates</code> to
+      <code class="language-markup">lib/example-templates</code> to
       <code class="language-markup">app/views</code>.
     </p>
   </li>

--- a/app/views/how-tos/build-basic-prototype/create-pages.html
+++ b/app/views/how-tos/build-basic-prototype/create-pages.html
@@ -7,7 +7,7 @@ extends 'how-tos/build-basic-prototype/_BASE.njk' %} {% block makePrototype %}
 <h3 id="create-a-start-page">Create a start page</h3>
 <p>
   Copy the <code class="language-markup">{{exampleStart.url}}.html</code> file
-  from <code class="language-markup">docs/views/templates</code> to
+  from <code class="language-markup">lib/example-templates</code> to
   <code class="language-markup">app/views</code>.
 </p>
 <p>
@@ -52,7 +52,7 @@ extends 'how-tos/build-basic-prototype/_BASE.njk' %} {% block makePrototype %}
 <p>
   Make 2 copies of the
   <code class="language-markup">question-page.html</code> file from
-  <code class="language-markup">docs/views/templates</code> to
+  <code class="language-markup">lib/example-templates</code> to
   <code class="language-markup">app/views</code>.
 </p>
 <p>Rename the 2 file copies to:</p>
@@ -91,7 +91,7 @@ extends 'how-tos/build-basic-prototype/_BASE.njk' %} {% block makePrototype %}
 <p>
   Copy the
   <code class="language-markup">{{exampleCheckAnswers.url}}.html</code> file
-  from <code class="language-markup">docs/views/templates</code> to
+  from <code class="language-markup">lib/example-templates</code> to
   <code class="language-markup">app/views</code>.
 </p>
 <p>
@@ -106,7 +106,7 @@ extends 'how-tos/build-basic-prototype/_BASE.njk' %} {% block makePrototype %}
 <p>
   Copy the
   <code class="language-markup">{{exampleConfirmation.url}}.html</code> file
-  from <code class="language-markup">docs/views/templates</code> to
+  from <code class="language-markup">lib/example-templates</code> to
   <code class="language-markup">app/views</code>.
 </p>
 <p>

--- a/app/views/how-tos/build-basic-prototype/open-prototype-in-editor.html
+++ b/app/views/how-tos/build-basic-prototype/open-prototype-in-editor.html
@@ -25,7 +25,7 @@
     example, if a user should go to one page or another based on their answers (we'll cover this later)
   </li>
   <li>
-    <code class="language-markup">/docs/views/templates</code> has template
+    <code class="language-markup">/lib/example-templates</code> has template
     pages for you to copy into your prototype
   </li>
 </ul>

--- a/app/views/how-tos/passing-data-page.html
+++ b/app/views/how-tos/passing-data-page.html
@@ -23,10 +23,6 @@
 
       <p><a href="/examples/passing-data/passing-data-question-name">You can see an example here</a></p>
 
-      <p>The code for the example can be found in:</p>
-
-      <pre class="app-pre"><code>docs/views/examples/passing-data</code></pre>
-
       <h2>How to use</h2>
 
       <p>The kit stores data from inputs using the name attribute of the input.</p>

--- a/app/views/page-templates.html
+++ b/app/views/page-templates.html
@@ -18,7 +18,9 @@
 
       <h1 class="nhsuk-heading-xl">Page templates</h1>
 
-      <p>You can find some example templates for pages in the <strong>/docs/views/templates</strong> folder within your prototype. These include:</p>
+      <p>You can find some example templates for pages in the <strong>/lib/example-templates</strong> folder within your prototype (or /docs/templates in older versions of the kit).</p>
+
+      <p>These include:</p>
 
       <ul>
         <li>content pages</li>


### PR DESCRIPTION
In the new version of the kit the example templates have moved from `docs/views/examples/` to `lib/example-templates`.

This updates the folder references.

The `/page-templates` page mentions the previous location for anyone using an older version of the kit.

The tutorial doesn’t mention the previous location, on the basis that if you’re following it you are more likely to have just downloaded the most recent version.