### PR TITLE
Fixes duplicate text in prototype kit guide intro

### DIFF
--- a/app/views/how-tos/build-basic-prototype/index.html
+++ b/app/views/how-tos/build-basic-prototype/index.html
@@ -10,7 +10,7 @@
 {% block makePrototype %}
 
 <p>
-This tutorial shows you how to prototype a fictional "{{exampleServiceName}}" service that will:
+  This tutorial shows you how to prototype a fictional "{{exampleServiceName}}" service that will:
 </p>
 <ul class="nhsuk-list nhsuk-list--bullet">
   <li>ask 2 questions</li>
@@ -18,14 +18,12 @@ This tutorial shows you how to prototype a fictional "{{exampleServiceName}}" se
   <li>show a confirmation page</li>
 </ul>
 <p>
-It will take about an hour to finish this tutorial, after you install the prototype kit. 
+  It will take about an hour to finish this tutorial, after you install the prototype kit. 
 </p>
 
 <p>
-Our prototype will look a bit like this:
+  Our prototype will look a bit like this:
 </p>
-
-<p>Our prototype will look a bit like this:</p>
 
 <figure class="nhsuk-figure">
   <img class="nhsuk-figure__image" src="/images/tutorial-overview.png" alt="The first page has the title 'Start page' with the button 'Start now'. This is linked to a 2nd page with the title 'Question 1' and a 'Continue' button. This forks to 2 different pages. 1 is titled 'Ineligible'. 2 is titled Question 2. Question 2 is linked to a page titled 'Check answers'. This links to page 6, titled 'Complete'.">


### PR DESCRIPTION
Fixes duplicate text on this page: https://prototype-kit.service-manual.nhs.uk/how-tos/build-basic-prototype/index