### PR TITLE
fix skipped heading level

### DIFF
--- a/app/views/how-tos/build-basic-prototype/create-pages.html
+++ b/app/views/how-tos/build-basic-prototype/create-pages.html
@@ -4,7 +4,7 @@ your prototype in your editor" , "link" : "open-prototype-in-editor" } %} {%
 extends 'how-tos/build-basic-prototype/_BASE.njk' %} {% block makePrototype %}
 
 <p>Create pages by copying template files that come with the prototype kit.</p>
-<h3 id="create-a-start-page">Create a start page</h3>
+<h2 id="create-a-start-page">Create a start page</h2>
 <p>
   Copy the <code class="language-markup">{{exampleStart.url}}.html</code> file
   from <code class="language-markup">lib/example-templates</code> to
@@ -19,7 +19,7 @@ extends 'how-tos/build-basic-prototype/_BASE.njk' %} {% block makePrototype %}
   >
   to preview <code class="language-markup">{{exampleStart.url}}.html</code>.
 </p>
-<h4 id="change-the-service-name">Change the service name</h4>
+<h3 id="change-the-service-name">Change the service name</h3>
 <p>
   You'll normally edit the HTML to make changes to pages, but the service name
   is in a config file. This is so we can change it in one place to update it on
@@ -48,7 +48,7 @@ extends 'how-tos/build-basic-prototype/_BASE.njk' %} {% block makePrototype %}
   refreshing. But for this config change, you need to refresh the page. You
   should see your service name change on the Start page.
 </p>
-<h3 id="question-pages">Question pages</h3>
+<h2 id="question-pages">Question pages</h2>
 <p>
   Make 2 copies of the
   <code class="language-markup">question-page.html</code> file from
@@ -87,7 +87,7 @@ extends 'how-tos/build-basic-prototype/_BASE.njk' %} {% block makePrototype %}
     "text": </code>
   to "{{exampleTextArea.title}}".
 </p>
-<h3 id="{{exampleCheckAnswers.url}}-page">Check answers page</h3>
+<h2 id="{{exampleCheckAnswers.url}}-page">Check answers page</h2>
 <p>
   Copy the
   <code class="language-markup">{{exampleCheckAnswers.url}}.html</code> file
@@ -102,7 +102,7 @@ extends 'how-tos/build-basic-prototype/_BASE.njk' %} {% block makePrototype %}
   to check.
 </p>
 
-<h3 id="confirmation-page">Confirmation page</h3>
+<h2 id="confirmation-page">Confirmation page</h2>
 <p>
   Copy the
   <code class="language-markup">{{exampleConfirmation.url}}.html</code> file


### PR DESCRIPTION
Fixes this page that skips from h1 to h3: https://prototype-kit.service-manual.nhs.uk/how-tos/build-basic-prototype/create-pages