### PR TITLE
Include auto-store-data script

### DIFF
--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -1,3 +1,4 @@
 <!-- Javascript -->
 <script src="/js/main.js"></script>
 <script src="/js/prism.js"></script>
+<script src="/js/auto-store-data.js"></script>


### PR DESCRIPTION
This script adds a hidden checkbox to all forms containing checkboxes, with the same name but a value of `_unchecked`.

This is useful for making sure that the values are always stored in an array, even when a single item is checked, as well as being able to more easily update data when a checkbox is unchecked.

The script was somehow not being referenced, which caused a bug.

Fixes #218