### PR TITLE
Update guides to use new 'value' option instead of 'checked' filter

### DIFF
--- a/app.js
+++ b/app.js
@@ -93,7 +93,6 @@ app.use(bodyParser.urlencoded({
 // Automatically store all data users enter
 if (useAutoStoreData === 'true') {
   app.use(utils.autoStoreData);
-  utils.addCheckedFunction(nunjucksAppEnv);
 }
 
 // Warn if node_modules folder doesn't exist

--- a/app/views/examples/passing-data/passing-data-check-answers.html
+++ b/app/views/examples/passing-data/passing-data-check-answers.html
@@ -61,7 +61,7 @@
           </dt>
           <dd class="nhsuk-summary-list__value">
             <ul class="nhsuk-list nhsuk-u-margin-bottom-1">
-              {% for item in data['condition'] %}
+              {% for item in data.conditions %}
                 <li>{{ item }}</li>
               {% else %}
                 <li>No conditions selected</li>

--- a/app/views/examples/passing-data/passing-data-question-conditions.html
+++ b/app/views/examples/passing-data/passing-data-question-conditions.html
@@ -22,54 +22,45 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <form action="/examples/passing-data/passing-data-check-answers" method="post" class="form">
-        <div class="nhsuk-form-group">
-          <fieldset class="nhsuk-fieldset" aria-describedby="conditions-hint">
-            <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-              <h1 class="nhsuk-fieldset__heading">
-                Have you ever had any of these conditions?
-              </h1>
-            </legend>
-            <div class="nhsuk-hint" id="conditions-hint">
-              Select all that apply
-            </div>
-            <div class="nhsuk-checkboxes">
-              <div class="nhsuk-checkboxes__item">
-                <input class="nhsuk-checkboxes__input" id="conditions-1" name="condition" type="checkbox" value="Asthma"{{ checked("condition", "Asthma") }}>
-                <label class="nhsuk-label nhsuk-checkboxes__label" for="conditions-1">
-                  Asthma
-                </label>
-              </div>
-              <div class="nhsuk-checkboxes__item">
-                <input class="nhsuk-checkboxes__input" id="conditions-6" name="condition" type="checkbox" value="Epilepsy"{{ checked("condition", "Epilepsy") }}>
-                <label class="nhsuk-label nhsuk-checkboxes__label" for="conditions-6">
-                  Epilepsy
-                </label>
-              </div>
-              <div class="nhsuk-checkboxes__item">
-                <input class="nhsuk-checkboxes__input" id="conditions-7" name="condition" type="checkbox" value="Heart Disease"{{ checked("condition", "Heart Disease") }}>
-                <label class="nhsuk-label nhsuk-checkboxes__label" for="conditions-7">
-                  Heart disease
-                </label>
-              </div>
-              <div class="nhsuk-checkboxes__item">
-                <input class="nhsuk-checkboxes__input" id="conditions-8" name="condition" type="checkbox" value="High blood pressure"{{ checked("condition", "High blood pressure") }}>
-                <label class="nhsuk-label nhsuk-checkboxes__label" for="conditions-8">
-                  High blood pressure
-                </label>
-              </div>
-            </div>
-          </fieldset>
-        </div>
-        <button class="nhsuk-button">Continue</button>
-      </form>
-      <div class="nhsuk-back-link">
-        <a href="/examples/passing-data/passing-data-question-contact" class="nhsuk-back-link__link">
-        <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" height="34" width="34">
-          <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
-        </svg>
-        Change my previous answer</a>
-      </div>
 
+        {{ checkboxes({
+          idPrefix: "conditions",
+          name: "conditions",
+          fieldset: {
+            legend: {
+              text: "Have you ever had any of these conditions?",
+              classes: "nhsuk-fieldset__legend--l",
+              isPageHeading: true
+            }
+          },
+          hint: {
+            text: "Select all that apply"
+          },
+          values: data.conditions,
+          items: [
+            {
+              value: "Asthma",
+              text: "Asthma"
+            },
+            {
+              value: "Epilepsy",
+              text: "Epilepsy"
+            },
+            {
+              value: "Heart disease",
+              text: "Heart disease"
+            },
+            {
+              value: "High blood pressure",
+              text: "High blood pressure"
+            }
+          ]
+        }) }}
+
+        {{ button({
+          text: "Continue"
+        }) }}
+      </form>
     </div>
   </div>
 {% endblock %}

--- a/app/views/examples/passing-data/passing-data-question-contact.html
+++ b/app/views/examples/passing-data/passing-data-question-contact.html
@@ -22,39 +22,38 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <form action="/examples/passing-data/passing-data-question-conditions" method="post" class="form">
-        <fieldset class="nhsuk-fieldset">
-          <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
-            <h1 class="nhsuk-fieldset__heading">
-              How would you prefer the GP to contact you?
-            </h1>
-          </legend>
-          <div class="nhsuk-form-group">
-            <div class="nhsuk-radios">
-              <div class="nhsuk-radios__item">
-                <input class="nhsuk-radios__input" id="contact-phone" name="contact" type="radio" value="By phone" {{ checked("contact", "By phone") }}>
-                <label class="nhsuk-label nhsuk-radios__label" for="contact-phone">By phone</label>
-              </div>
-              <div class="nhsuk-radios__item">
-                <input class="nhsuk-radios__input" id="contact-email" name="contact" type="radio" value="By email" {{ checked("contact", "By email") }}>
-                <label class="nhsuk-label nhsuk-radios__label" for="contact-email">By email</label>
-              </div>
-              <div class="nhsuk-radios__item">
-                <input class="nhsuk-radios__input" id="contact-post" name="contact" type="radio" value="By post" {{ checked("contact", "By post") }}>
-                <label class="nhsuk-label nhsuk-radios__label" for="contact-post">By post</label>
-              </div>
-            </div>
-          </div>
-        </fieldset>
-        <button type="submit" class="nhsuk-button">Continue</button>
-      </form>
-      <div class="nhsuk-back-link">
-        <a href="/examples/passing-data/passing-data-question-name" class="nhsuk-back-link__link">
-        <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" height="34" width="34">
-          <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
-        </svg>
-        Change my previous answer</a>
-      </div>
 
+        {{ radios({
+          idPrefix: "contact",
+            name: "contact",
+            fieldset: {
+              legend: {
+                text: "How would you prefer the GP to contact you?",
+                classes: "nhsuk-fieldset__legend--l",
+                isPageHeading: true
+              }
+            },
+            value: data.contact,
+            items: [
+              {
+                value: "By phone",
+                text: "By phone"
+              },
+              {
+                value: "By email",
+                text: "By email"
+              },
+              {
+                value: "By post",
+                text: "By post"
+              }
+            ]
+          }) }}
+
+          {{ button({
+            text: "Continue"
+          }) }}
+      </form>
     </div>
   </div>
 

--- a/app/views/how-tos/build-basic-prototype/_BASE.njk
+++ b/app/views/how-tos/build-basic-prototype/_BASE.njk
@@ -5,7 +5,7 @@
 {% set exampleServiceName = "Order a test to check if you have magical powers" %}
 {% set exampleServiceURL = "magical-powers" %}
 {% set exampleStart = { url: "start-page" }  %}
-{% set exampleRadios = { "url" : "magical-powers", "title" : "Have you felt symptoms of magical powers in the last 30 days?", "legend" : "magical-powers", "summary" : "Symptoms of magical powers" }  %}
+{% set exampleRadios = { "url" : "magical-powers", "title" : "Have you felt symptoms of magical powers in the last 30 days?", "legend" : "magicalPowers", "summary" : "Symptoms of magical powers" }  %}
 {% set exampleTextArea = { "url" : "details", "title" : "Tell us your symptoms of magical powers", legend: "details", "summary" : "Details of the symptoms" } %}
 {% set exampleCheckAnswers = { url: "check-your-answers", title : "Check your answers" }  %}
 {% set exampleConfirmation = { url: "confirmation-page", title:  "Confirmation" } %}

--- a/app/views/how-tos/build-basic-prototype/branching.html
+++ b/app/views/how-tos/build-basic-prototype/branching.html
@@ -86,7 +86,7 @@ their answers" , "link" : "let-user-change-answers" } %} {% extends
 router.post('/{{exampleRadios.url}}-answer', function (req, res) {
 
 // Make a variable and give it the value from '{{exampleRadios.legend}}'
-var magicPowers = req.session.data['{{exampleRadios.legend}}']
+var magicPowers = req.session.data.{{exampleRadios.legend}}
 
 // Check whether the variable matches a condition
 if (magicPowers == "yes"){

--- a/app/views/how-tos/build-basic-prototype/let-user-change-answers.html
+++ b/app/views/how-tos/build-basic-prototype/let-user-change-answers.html
@@ -11,13 +11,13 @@ page" , "link" : "show-users-answers" } %} {% extends
 <ol class="nhsuk-list nhsuk-list--number">
   <li>
     Find the value
-    <code class="language-markup">data['{{exampleRadios.legend}}']</code>, then change the
+    <code class="language-markup">data.{{exampleRadios.legend}}</code>, then change the
     the <code class="language-markup">href</code> value from <code class="language-markup">'#'</code> to
     <code class="language-markup">'/{{exampleRadios.url}}'</code>
   </li>
   <li>
     Find the value
-    <code class="language-markup">data['{{exampleTextArea.legend}}']</code>, then change the
+    <code class="language-markup">data.{{exampleTextArea.legend}}</code>, then change the
     the <code class="language-markup">href</code> value from <code class="language-markup">'#'</code> to
     <code class="language-markup">'/{{exampleTextArea.url}}'</code>
   </li>
@@ -30,38 +30,46 @@ page" , "link" : "show-users-answers" } %} {% extends
   Show the user's answer in question&nbsp;1
 </h2>
 <p>
-  Radios and checkboxes have a
-  <code class="language-markup">checked</code> option to set whether they are
-  selected (checked) or not when the page loads.
+  Radios let you select which option should be pre-selected by setting a <code class="language-markup">value</code> option to the value of the selected option.
 </p>
 <p>
   Open the <code class="language-markup">{{exampleRadios.url}}.html</code> file
   in your <code class="language-markup">app/views</code> folder.
 </p>
 <p>
-  For each of the <code class="language-markup">items</code>, we'll add a
-  <code class="language-markup">checked</code> value, like this:
+  Update the radios component to add <code class="language-markup">value: data.magicalPowers</code>, like this:
 </p>
-<pre tabindex="0"><code class="language-markup" >&#123;
-  value: "yes",
-  text: "Yes",
-  checked: checked("magical-powers", "yes")
-&#125;,
-&#123;
-  value: "no",
-  text: "No",
-  checked: checked("magical-powers", "no")
-  &#125;,
-  &#123;
-  value: "not sure",
-  text: "I'm not sure",
-  checked: checked("magical-powers", "not sure")
-  &#125;,
-</code></pre>
-<p>
-  In each case make sure the spelling is exactly the same as the
-  <code class="language-markup">value</code>.
-</p>
+<pre
+  class="app-pre language-markup"><code class="language-markup" >&#123;{ radios({
+  idPrefix: "magical-powers",
+  name: "magicalPowers",
+  fieldset: {
+    legend: {
+      text: "{{ exampleRadios.title }}"" ,
+      classes: "nhsuk-fieldset__legend--l",
+      isPageHeading: true
+    }
+  },
+  hint: {
+    html: "For example, things moving when you have strong feelings or hearing someone's thoughts."
+  },
+  value: data.magicalPowers,
+  items: [
+  {
+    value: "yes",
+    text: "Yes"
+  },
+  {
+    value: "no",
+    text: "No"
+  },
+  {
+    value: "not sure",
+    text: "I'm not sure"
+  }
+]
+}) &#125;&#125;</code></pre>
+
 <p>
   <a href="http://localhost:3000/{{exampleRadios.url}}"
     >Go to http://localhost:3000/{{exampleRadios.url}}</a
@@ -73,7 +81,7 @@ page" , "link" : "show-users-answers" } %} {% extends
   Show the user's answer in question&nbsp;2
 </h2>
 <p>
-  Text inputs and textareas have a <code class="language-markup">value</code> to
+  Text inputs and textareas work in a similar way to radios, adding <code class="language-markup">value</code> to
   set what text appears in them when the page loads.
 </p>
 <p>
@@ -83,7 +91,7 @@ page" , "link" : "show-users-answers" } %} {% extends
 </p>
 <p>
   Go to  <code class="language-markup">id: "{{exampleTextArea.legend}}",</code> and add a new line
-  <code class="language-markup">value: data['{{exampleTextArea.legend}}'],</code>
+  <code class="language-markup">value: data.{{exampleTextArea.legend}},</code>
   like this:
 </p>
 
@@ -91,7 +99,7 @@ page" , "link" : "show-users-answers" } %} {% extends
    textarea({
     name: "{{exampleTextArea.legend}}",
     id: "{{exampleTextArea.legend}}",
-    value: data['{{exampleTextArea.legend}}'],
+    value: data.{{exampleTextArea.legend}},
     label: {
       text: "Tell us your symptoms of magical powers",
       classes: "nhsuk-label--l",

--- a/app/views/how-tos/build-basic-prototype/let-user-change-answers.html
+++ b/app/views/how-tos/build-basic-prototype/let-user-change-answers.html
@@ -45,7 +45,7 @@ page" , "link" : "show-users-answers" } %} {% extends
   name: "magicalPowers",
   fieldset: {
     legend: {
-      text: "{{ exampleRadios.title }}"" ,
+      text: "{{ exampleRadios.title }}",
       classes: "nhsuk-fieldset__legend--l",
       isPageHeading: true
     }

--- a/app/views/how-tos/build-basic-prototype/show-users-answers.html
+++ b/app/views/how-tos/build-basic-prototype/show-users-answers.html
@@ -24,7 +24,7 @@ question 2" , "link" : "use-components-2" } %} {% extends
     In <code class="language-markup">value</code> on the next line,
     change '485 777 3456' to
     <code class="language-markup"
-      >data['{{exampleRadios.legend}}']</code
+      >data.{{exampleRadios.legend}}</code
     >.
   </li>
 </ol>
@@ -51,7 +51,7 @@ question 2" , "link" : "use-components-2" } %} {% extends
     In the <code class="language-markup">value</code> on the next line,
     change 'Kevin Francis' to
     <code class="language-markup">
-      data['{{exampleTextArea.legend}}']</code
+      data.{{exampleTextArea.legend}}</code
     >.
   </li>
   <li>
@@ -106,7 +106,7 @@ question 2" , "link" : "use-components-2" } %} {% extends
               text: "Magical power symptoms in the last 30 days"
             },
             value: {
-              text: data["magical-powers"]
+              text: data.magical-powers
             },
             actions: {
               items: [
@@ -123,7 +123,7 @@ question 2" , "link" : "use-components-2" } %} {% extends
               text: "Details of symptoms"
             },
             value: {
-              text: data["details"]
+              text: data.details
             },
             actions: {
               items: [

--- a/app/views/how-tos/build-basic-prototype/show-users-answers.html
+++ b/app/views/how-tos/build-basic-prototype/show-users-answers.html
@@ -106,7 +106,7 @@ question 2" , "link" : "use-components-2" } %} {% extends
               text: "Magical power symptoms in the last 30 days"
             },
             value: {
-              text: data.magical-powers
+              text: data.magicalPowers
             },
             actions: {
               items: [

--- a/app/views/how-tos/build-basic-prototype/use-components.html
+++ b/app/views/how-tos/build-basic-prototype/use-components.html
@@ -67,15 +67,15 @@ set prev = { "title" : "Link your pages together" , "link" :
   </li>
   <li>
     In the <code class="language-markup">items: &#123; text:</code> areas delete all the text after "Yes" and "No"
-  
+
   </li>
 </ol>
 <p>Your component code should now look like this:</p>
 
 <pre
   class="app-pre language-markup"><code class="language-markup" >&#123;{ radios({
-  idPrefix: "example-hints",
-  name: "example-hints",
+  idPrefix: "magical-powers",
+  name: "magicalPowers",
   fieldset: {
     legend: {
       text: "{{ exampleRadios.title }}"" ,

--- a/app/views/how-tos/passing-data-page.html
+++ b/app/views/how-tos/passing-data-page.html
@@ -62,7 +62,7 @@
 }) }}
 {% endraw %}</code></pre>
 
-      <p>For a checkboxes and dates you need to use the <code>values</code> option (plural) instead:</p>
+      <p>For checkboxes and dates you need to use the <code>values</code> option (plural) instead:</p>
 
       <pre class="app-pre"><code>&#123;&#123; checkboxes({
   idPrefix: "conditions",

--- a/app/views/how-tos/passing-data-page.html
+++ b/app/views/how-tos/passing-data-page.html
@@ -62,7 +62,7 @@
 }) }}
 {% endraw %}</code></pre>
 
-      <p>For a radios and checkboxes you need to use the "checked" filter:</p>
+      <p>For a checkboxes and dates you need to use the <code>values</code> option (plural) instead:</p>
 
       <pre class="app-pre"><code>&#123;&#123; checkboxes({
   idPrefix: "conditions",
@@ -74,32 +74,31 @@
       isPageHeading: true
     }
   },
+  values: data.conditions,
   hint: {
     text: "Select all that apply"
   },
   items: [
     {
       value: "Asthma",
-      text: "Asthma",
-      checked: checked("condition", "Asthma")
+      text: "Asthma"
     },
     {
       value: "Cancer",
-      text: "Cancer",
-      checked: checked("condition", "Cancer")
+      text: "Cancer"
     },
     {
       value: "Lung disease",
-      text: "Lung disease",
-      checked: checked("condition", "Lung disease")
+      text: "Lung disease"
     },
     {
       value: "Diabetes",
-      text: "Diabetes",
-      checked: checked("condition", "Diabetes")
+      text: "Diabetes"
     }
   ]
 }) &#125;&#125;</code></pre>
+
+      <p>Being able to set checkboxes and radios in this way was added in <a href="https://github.com/nhsuk/nhsuk-frontend/releases/tag/v9.2.0">NHS Frontend version 9.2.0</a>.</p>
 
       <h3>Clearing data</h3>
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,41 +14,6 @@ exports.addNunjucksFilters = function (env) { /* eslint-disable-line func-names 
   });
 };
 
-// Add Nunjucks function called 'checked' to populate radios and checkboxes
-exports.addCheckedFunction = function (env) { /* eslint-disable-line func-names */
-  env.addGlobal('checked', function (name, value) { /* eslint-disable-line func-names */
-    // Check data exists
-    if (this.ctx.data === undefined) {
-      return '';
-    }
-
-    // Use string keys or object notation to support:
-    // checked("field-name")
-    // checked("['field-name']")
-    // checked("['parent']['field-name']")
-    const matchedName = !name.match(/[.[]/g) ? `['${name}']` : name;
-    const storedValue = getKeypath(this.ctx.data, matchedName);
-
-    // Check the requested data exists
-    if (storedValue === undefined) {
-      return '';
-    }
-
-    let checked = '';
-
-    // If data is an array, check it exists in the array
-    if (Array.isArray(storedValue)) {
-      if (storedValue.indexOf(value) !== -1) {
-        checked = 'checked';
-      }
-    } else if (storedValue === value) {
-      // The data is just a simple value, check it matches
-      checked = 'checked';
-    }
-    return checked;
-  });
-};
-
 // Try to match a request to a template, for example a request for /test
 // would look for /app/views/test.html
 // and /app/views/test/index.html

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,4 @@
 // NPM dependencies
-const { get: getKeypath } = require('lodash');
 const path = require('path');
 
 // Require core and custom filters, merges to one object


### PR DESCRIPTION
Since [version 9.2.0 of NHS Frontend](https://github.com/nhsuk/nhsuk-frontend/releases/tag/v9.2.0) there’s now an easier, nicer way of setting the default selected radio option or default checked checkboxes.

Instead of using the `checked()` filter on each `item` within radios and checkboxes, the `value` (for radios) or `values` (for checkbox) of the selected items can be set at the top level of the Nunjucks params.

This pull request updates the guidance to use the newer, easier way of doing this.

The `checked` function/filter is also deleted from the guidance site as it’s no longer needed (but will remain in the kit itself for backwards-compatibility until at least the next major release).