### PR TITLE
Update example page to use new Panel component

### DIFF
--- a/app/views/examples/passing-data/passing-data-confirmation.html
+++ b/app/views/examples/passing-data/passing-data-confirmation.html
@@ -17,42 +17,19 @@
   }) }}
 {% endblock %}
 
-{% block main %}
-  <div class="nhsuk-width-container">
-    <main class="nhsuk-main-wrapper nhsuk-main-wrapper--s" id="maincontent" role="main">
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
 
-    {% block content %}
-      <div class="nhsuk-grid-row">
-        <div class="nhsuk-grid-column-two-thirds">
+      {{ panel({
+        titleText: "Application complete",
+        html: "Confirmation has been sent to you by email"
+      }) }}
 
-          <div class="nhsuk-card nhsuk-card--confirmation nhsuk-u-margin-top-0 nhsuk-u-margin-bottom-4">
 
-            <div class="nhsuk-card__content">
-    
-              <h1 class="nhsuk-card__title nhsuk-u-margin-bottom-4">
-                Application complete
-              </h1>
-    
-              <p class="nhsuk-u-font-size-24">
-                Your reference number
-                <br>
-                <strong class="nhsuk-u-font-size-32">HDJ2123F</strong>
-              </p>
-              
-            </div>
-    
-          </div>
 
-            <p>
-              We have sent you a confirmation email.
-            </p>
-
-        </div>
-      </div>
-    {% endblock %}
-
-  </main>
-</div>
+    </div>
+  </div>
 {% endblock %}
 
 {% block footer %}

--- a/app/views/template.html
+++ b/app/views/template.html
@@ -31,6 +31,7 @@
 {%- from 'tabs/macro.njk' import tabs %} 
 {%- from 'tag/macro.njk' import tag %}
 {%- from 'textarea/macro.njk' import textarea %}
+{%- from 'panel/macro.njk' import panel %}
 
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
New [Panel component](https://service-manual.nhs.uk/design-system/components/panel) was released in [NHS Frontend 9.3.0](https://github.com/nhsuk/nhsuk-frontend/releases/tag/v9.3.0).

This updates an example in the prototype kit docs to use the new component.

## Screenshots

| Before | After |
|--------|-------|
| ![previous-confirmation-screen](https://github.com/user-attachments/assets/9f11cbd8-3d6d-4c9f-9a1e-120d505eb8a5) | ![new-confirmation-screen](https://github.com/user-attachments/assets/915aefad-1075-45c4-aec3-f947132de649) |


