### PR TITLE
Update to NHS prototype kit 5.3.0

### DIFF
--- a/app/views/whats-new/updates.html
+++ b/app/views/whats-new/updates.html
@@ -19,6 +19,13 @@
 
       <p class="nhsuk-lede-text">Changes made in each major and minor version.</p>
 
+      <h2>5.3.0 - 14 February 2025</h2>
+
+      <ul>
+        <li><a href="https://service-manual.nhs.uk/design-system/components/panel">Panel component</a> added</li>
+        <li>Checkboxes and radios items can now more easily be pre-selected. See <a href="/how-tos/passing-data-page">passing data page to page guide</a>.</li>
+      </ul>
+
       <h2>5.2.0 - 13 December 2024</h2>
 
       <ul>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nhsuk-prototype-kit",
   "version": "0.1.0",
-  "prototypeKitVersion": "5.2.0",
+  "prototypeKitVersion": "5.3.0",
   "description": "Website and documentation for the NHS prototype kit.",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
This updates the guidance website to point to the new 5.3.0 release of the prototype kit zip file, and updates the Updates page to describe the new features.