### PR TITLE
Upgrade nhsuk frontend

### DIFF
--- a/app/assets/sass/main.scss
+++ b/app/assets/sass/main.scss
@@ -42,4 +42,9 @@
   padding: 16px 16px 16px 0;
 }
 
+// Temporary fix until this is fixed in NHS frontend
+// See https://github.com/nhsuk/nhsuk-frontend/pull/1292
+.nhsuk-hero a.nhsuk-button {
+  color: $nhsuk-text-color;
+}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "gulp-sass": "^5.1.0",
         "highlight.js": "^11.2.0",
         "lodash": "^4.17.21",
-        "nhsuk-frontend": "^9.3.0",
+        "nhsuk-frontend": "^9.4.1",
         "nunjucks": "^3.2.4",
         "path": "^0.12.7",
         "sass": "^1.82.0"
@@ -11467,12 +11467,12 @@
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "node_modules/nhsuk-frontend": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-9.3.0.tgz",
-      "integrity": "sha512-XZqmZN8YMK/j5cHi7O5AEDigFzPPZJFhBOPkYO/kNIw6k3eveedfRZetgVzOVurI7GUQmWd9IF67eVwR8LFh7w==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-9.4.1.tgz",
+      "integrity": "sha512-0++l57I4qvAYInYJytwU57pRt5j5iQ2bYjD8PfJUfpMNLep0yOmcS2hwwr+JvhexT8pM07VwngK1wUzhCSOaQQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=20.0.0"
+        "node": "^20.9.0 || ^22.11.0"
       }
     },
     "node_modules/node-addon-api": {
@@ -23277,9 +23277,9 @@
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "nhsuk-frontend": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-9.3.0.tgz",
-      "integrity": "sha512-XZqmZN8YMK/j5cHi7O5AEDigFzPPZJFhBOPkYO/kNIw6k3eveedfRZetgVzOVurI7GUQmWd9IF67eVwR8LFh7w=="
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-9.4.1.tgz",
+      "integrity": "sha512-0++l57I4qvAYInYJytwU57pRt5j5iQ2bYjD8PfJUfpMNLep0yOmcS2hwwr+JvhexT8pM07VwngK1wUzhCSOaQQ=="
     },
     "node-addon-api": {
       "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "gulp-sass": "^5.1.0",
     "highlight.js": "^11.2.0",
     "lodash": "^4.17.21",
-    "nhsuk-frontend": "^9.3.0",
+    "nhsuk-frontend": "^9.4.1",
     "nunjucks": "^3.2.4",
     "path": "^0.12.7",
     "sass": "^1.82.0"


### PR DESCRIPTION
This upgrades NHS frontend to 9.4.1 and applies a temporary fix for the button on the homepage.

I’ll switch to using the template now included within NHS frontend as a separate follow-up PR.