### PR TITLE
Set page title for homepage

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -1,5 +1,9 @@
 {% extends 'layout.html' %}
 
+{% block pageTitle %}
+  NHS prototype kit
+{% endblock %}
+
 {% block header %}
   {{ super() }}
 


### PR DESCRIPTION
Currently it is just "NHS", as it hasn’t been set.