### PR TITLE
Fix nested declarations warning

### DIFF
--- a/app/assets/sass/nhsuk.scss
+++ b/app/assets/sass/nhsuk.scss
@@ -621,17 +621,15 @@ main .app-list-signage a[href=""] {
 }
 
 .nhsuk-related-nav__heading {
-  @include nhsuk-font-size(19, $line-height: 1.2);
-
   margin-bottom: 12px;
   padding-top: nhsuk-spacing(3);
+  @include nhsuk-font-size(19, $line-height: 1.2);
 }
 
 .nhsuk-related-nav__list {
-  @include nhsuk-font-size(16);
-
   list-style: none;
   padding-left: 0;
+  @include nhsuk-font-size(16);
 }
 
 // ==========================================================================


### PR DESCRIPTION
This resolves the following Sass deprecation warning:

```
Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule.
```