### PR TITLE
Replace references to examples templates with links to service manual

### DIFF
--- a/app/views/how-tos/build-basic-prototype/branching.html
+++ b/app/views/how-tos/build-basic-prototype/branching.html
@@ -32,10 +32,26 @@ their answers" , "link" : "let-user-change-answers" } %} {% extends
     <p>
       Make an
       <code>{{exampleIneligible.url}}.html</code> page
-      by copying <code>content-page.html</code> from
-      <code>lib/example-templates</code> to
+      by copying this code to
       <code>app/views</code>.
     </p>
+
+{% call codeSnippet({ language: "html" }) %}{% raw %}
+{% extends "layout.html" %}
+{% set pageName = "Ineligible" %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+
+      <h1>{{ pageName }}</h1>
+
+    </div>
+  </div>
+{% endblock %}
+{% endraw %}{% endcall %}
+
+
   </li>
   <li>
     <p>

--- a/app/views/how-tos/build-basic-prototype/create-pages.html
+++ b/app/views/how-tos/build-basic-prototype/create-pages.html
@@ -3,16 +3,27 @@ together" , "link" : "link-pages-together" } %} {% set prev = { "title" : "Open
 your prototype in your editor" , "link" : "open-prototype-in-editor" } %} {%
 extends 'how-tos/build-basic-prototype/_BASE.njk' %} {% block makePrototype %}
 
-<p>Create pages by copying template files that come with the prototype kit.</p>
+<p>Create pages by copying examples from the <a href="https://service-manual.nhs.uk/design-system/patterns">patterns section of the NHS Service manual</a>.</p>
 <h2 id="create-a-start-page">Create a start page</h2>
 <p>
-  Copy the <code>{{exampleStart.url}}.html</code> file
-  from <code>lib/example-templates</code> to
-  <code>app/views</code>.
+  Create an empty file named <code>{{exampleStart.url}}.html</code> in your <code>app/views</code> folder.
 </p>
+
+<p>Visit the <a href="https://service-manual.nhs.uk/design-system/patterns/start-page">start page pattern</a> and select the Nunjucks option under the first example. This will reveal the Nunjucks code.</p>
+
+<p>Copy the Nunjucks code into your empty file. There is a ‘Copy code’ button to make this easier.</p>
+
+<p>Add this line to the very top of your code:</p>
+
+{% call codeSnippet({ language: "html" }) %}{% raw %}
+{% extends "layout.html" %}
+{% endraw %}{% endcall %}
+
 <p>
   Preview the pages in your prototype by going to
-  ht<span>tp</span>://localhost:3000/name-of-HTML-file in your web browser. For
+  <code>http://localhost:3000/name-of-file</code> in your web browser.</p>
+
+<p>For
   example,
   <a href="http://localhost:3000/{{exampleStart.url}}"
     >go to http://localhost:3000/{{exampleStart.url}}</a
@@ -49,18 +60,22 @@ extends 'how-tos/build-basic-prototype/_BASE.njk' %} {% block makePrototype %}
   should see your service name change on the Start page.
 </p>
 <h2 id="question-pages">Question pages</h2>
-<p>
-  Make 2 copies of the
-  <code>question-page.html</code> file from
-  <code>lib/example-templates</code> to
-  <code>app/views</code>.
-</p>
-<p>Rename the 2 file copies to:</p>
-<ul class="nhsuk-list nhsuk-list--bullet">
 
+<p>Create 2 empty files for question pages in <code>app/views</code> named:</p>
+
+<ul class="nhsuk-list nhsuk-list--bullet">
   <li><code>{{exampleRadios.url}}.html</code></li>
   <li><code>{{exampleTextArea.url}}.html</code></li>
 </ul>
+
+<p>Visit  the <a href="https://service-manual.nhs.uk/design-system/patterns/question-pages">question page pattern</a> and copy the Nunjucks from the example into each file.</p>
+
+<p>As before, add this line to the top of each file:</p>
+
+{% call codeSnippet({ language: "html" }) %}{% raw %}
+{% extends "layout.html" %}
+{% endraw %}{% endcall %}
+
 <p>Go to the following URLs to check your pages:</p>
 <ul class="nhsuk-list nhsuk-list--bullet">
 
@@ -88,12 +103,19 @@ extends 'how-tos/build-basic-prototype/_BASE.njk' %} {% block makePrototype %}
   to "{{exampleTextArea.title}}".
 </p>
 <h2 id="{{exampleCheckAnswers.url}}-page">Check answers page</h2>
+
 <p>
-  Copy the
-  <code>{{exampleCheckAnswers.url}}.html</code> file
-  from <code>lib/example-templates</code> to
-  <code>app/views</code>.
+  Create an empty file named <code>{{exampleCheckAnswers.url}}.html</code> in <code>app/views</code>.
 </p>
+
+<p>Copy the Nunjucks code from the <a href="https://service-manual.nhs.uk/design-system/patterns/check-answers">check answers pattern page</a> and add it to the file.</p>
+
+<p>Add this line to the top of the file:</p>
+
+{% call codeSnippet({ language: "html" }) %}{% raw %}
+{% extends "layout.html" %}
+{% endraw %}{% endcall %}
+
 <p>
   Go to
   <a href="http://localhost:3000/{{exampleCheckAnswers.url}}"
@@ -103,12 +125,19 @@ extends 'how-tos/build-basic-prototype/_BASE.njk' %} {% block makePrototype %}
 </p>
 
 <h2 id="confirmation-page">Confirmation page</h2>
+
 <p>
-  Copy the
-  <code>{{exampleConfirmation.url}}.html</code> file
-  from <code>lib/example-templates</code> to
-  <code>app/views</code>.
+  Create an empty file named <code>{{exampleConfirmation.url}}.html</code> in <code>app/views</code>.
 </p>
+
+<p>Copy the Nunjucks code from the <a href="https://service-manual.nhs.uk/design-system/patterns/confirmation-page">confirmation page pattern</a> into the file.</p>
+
+<p>Add this line to the top of the file:</p>
+
+{% call codeSnippet({ language: "html" }) %}{% raw %}
+{% extends "layout.html" %}
+{% endraw %}{% endcall %}
+
 <p>
   Go to
   <a href="http://localhost:3000/{{exampleConfirmation.url}}"

--- a/app/views/how-tos/build-basic-prototype/create-pages.html
+++ b/app/views/how-tos/build-basic-prototype/create-pages.html
@@ -68,7 +68,7 @@ extends 'how-tos/build-basic-prototype/_BASE.njk' %} {% block makePrototype %}
   <li><code>{{exampleTextArea.url}}.html</code></li>
 </ul>
 
-<p>Visit  the <a href="https://service-manual.nhs.uk/design-system/patterns/question-pages">question page pattern</a> and copy the Nunjucks from the example into each file.</p>
+<p>Visit the <a href="https://service-manual.nhs.uk/design-system/patterns/question-pages">question page pattern</a> and copy the Nunjucks from the example into each file.</p>
 
 <p>As before, add this line to the top of each file:</p>
 

--- a/app/views/page-templates.html
+++ b/app/views/page-templates.html
@@ -18,22 +18,28 @@
 
       <h1 class="nhsuk-heading-xl">Page templates</h1>
 
-      <p>You can find some example templates for pages in the <strong>/lib/example-templates</strong> folder within your prototype (or /docs/templates in older versions of the kit).</p>
+      <p>You can find some example page templates in <a href="https://service-manual.nhs.uk/design-system/patterns">patterns section of the NHS service manual</a>.</p>
 
       <p>These include:</p>
 
       <ul>
-        <li>content pages</li>
-        <li>question pages</li>
-        <li>check your answers</li>
-        <li>a confirmation page</li>
+        <li><a href="https://service-manual.nhs.uk/design-system/patterns/question-pages">question pages</a></li>
+        <li><a href="https://service-manual.nhs.uk/design-system/patterns/confirmation-page">confirmation pages</a></li>
+        <li><a href="https://service-manual.nhs.uk/design-system/patterns/check-answers">check answers pages</a></li>
+        <li><a href="https://service-manual.nhs.uk/design-system/patterns/complete-multiple-tasks">task list pages</a></li>
       </ul>
 
-      <p>To use one, copy and paste it from there into your <strong>/app/views</strong> folder.</p>
+      <p>To use one, copy and paste the Nunjucks code from the page into a new file in your <strong>/app/views</strong> folder.</p>
 
-      <p>There are also some templates for <a href="https://service-manual.nhs.uk/design-system/patterns">common patterns</a> in the NHS service manual.</p>
+      <p>The file name should end with <code>.html</code> and not contain any spaces, for example <code>what-are-your-symptoms.html</code></p>
 
-      <h2 class="nhsuk-heading-m">NHS website pages</h2>
+      <p>You will also need to add this line of code to the top of each page:</p>
+
+{% call codeSnippet({ language: "html" }) %}{% raw %}
+{% extends "layout.html" %}
+{% endraw %}{% endcall %}
+
+      <h2 class="nhsuk-heading-m nhsuk-u-margin-top-6">NHS website pages</h2>
 
       <p>If you are prototyping a service which includes pages on the NHS website, you can use these additional templates:</p>
 


### PR DESCRIPTION
We’ve now removed almost all the example templates from the prototype kit, as there are now pattern pages for them in the NHS Service manual instead, which include additional guidance. 🎉 

One small downside is that the examples in the service manual don’t the layout reference at the top, so the guidance now has to mention adding this to the top of each file:

```njk
{% extends "layout.html" %}
```

Fixes #295