### PR TITLE
Update version number of prototype kit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nhsuk-prototype-kit",
   "version": "0.1.0",
-  "prototypeKitVersion": "7.0.0",
+  "prototypeKitVersion": "7.0.1",
   "description": "Website and documentation for the NHS prototype kit.",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
This updates the link to .zip file download.

I've not added an entry to the [Updates page](https://prototype-kit.service-manual.nhs.uk/whats-new/updates) as we say there that we'll only mention major and minor versions.