### PR TITLE
Only specify the major version number in upgrade guide

### DIFF
--- a/app/views/how-tos/updating-the-kit.html
+++ b/app/views/how-tos/updating-the-kit.html
@@ -20,7 +20,7 @@
       </h1>
 
       {{ insetText({
-        html: "<p>If you are upgrading to version 7.0.0 of the NHS prototype kit, this also upgrades NHS frontend to version 10.0.0. You will need to follow the <a href=\"https://service-manual.nhs.uk/design-system/guides/updating-to-v10\">upgrading to version 10 guide</a> to make any required changes to your code.</p>"
+        html: "<p>If you are upgrading to version 7+ of the NHS prototype kit, this also upgrades NHS frontend to version 10+ You will need to follow the <a href=\"https://service-manual.nhs.uk/design-system/guides/updating-to-v10\">upgrading to version 10 guide</a> to make any required changes to your code.</p>"
       }) }}
 
       <ol>

--- a/app/views/how-tos/updating-the-kit.html
+++ b/app/views/how-tos/updating-the-kit.html
@@ -20,7 +20,7 @@
       </h1>
 
       {{ insetText({
-        html: "<p>If you are upgrading to version 7+ of the NHS prototype kit, this also upgrades NHS frontend to version 10+ You will need to follow the <a href=\"https://service-manual.nhs.uk/design-system/guides/updating-to-v10\">upgrading to version 10 guide</a> to make any required changes to your code.</p>"
+        html: "<p>If you are upgrading to NHS prototype kit version 7+, this also upgrades NHS frontend to version 10+ You will need to follow the <a href=\"https://service-manual.nhs.uk/design-system/guides/updating-to-v10\">upgrading to version 10 guide</a> to make any required changes to your code.</p>"
       }) }}
 
       <ol>


### PR DESCRIPTION
This makes the guide a bit more future-proof for when there are minor or patch releases of NHS frontend or the prototype kit.