### PR TITLE
Remove dotenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,7 @@ jspm_packages/
 # Output of 'npm pack'
 *.tgz
 
-# dotenv environment variables file
+# environment variables file
 .env
 
 # System Files

--- a/app.js
+++ b/app.js
@@ -5,14 +5,11 @@ const fs = require('fs');
 // External dependencies
 const bodyParser = require('body-parser');
 const cookieParser = require('cookie-parser');
-const dotenv = require('dotenv');
 const express = require('express');
 const nunjucks = require('nunjucks');
 const sessionInMemory = require('express-session');
 const highlightjs = require('highlight.js');
 
-// Run before other code to make sure variables from .env are available
-dotenv.config();
 
 // Local dependencies
 const packageInfo = require('./package.json');

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "browser-sync": "^3.0.4",
         "client-sessions": "^0.8.0",
         "cookie-parser": "^1.4.7",
-        "dotenv": "^16.4.7",
         "express": "^4.21.2",
         "express-session": "^1.18.2",
         "gulp": "^5.0.1",
@@ -4890,17 +4889,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/duplexify": {
@@ -17598,11 +17586,6 @@
       "requires": {
         "esutils": "^2.0.2"
       }
-    },
-    "dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ=="
     },
     "duplexify": {
       "version": "3.7.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "browser-sync": "^3.0.4",
     "client-sessions": "^0.8.0",
     "cookie-parser": "^1.4.7",
-    "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "express-session": "^1.18.2",
     "gulp": "^5.0.1",


### PR DESCRIPTION
This isn't needed much for this website, and if we do need it in future, Node 22 now has built-in support for reading `.env` files.