### PR TITLE
Use the pageName variable instead of pageTitle block

### DIFF
--- a/app/views/about.html
+++ b/app/views/about.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  About - NHS prototype kit
-{% endblock %}
+{% set pageName = "About" %}
 
 {% block beforeContent %}
   {{ breadcrumb({
@@ -16,7 +14,7 @@
 
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1>About</h1>
+      <h1>{{ pageName }}</h1>
 
       <p class="nhsuk-lede-text">The NHS prototype kit enables you to make interactive prototypes that look like NHS services, such as the NHS website (<a href="http://nhs.uk">www.nhs.uk</a>). The prototypes you make are a great way to show ideas to others and for conducting user research.</p>
 

--- a/app/views/cookies.html
+++ b/app/views/cookies.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Cookies - NHS prototype kit
-{% endblock %}
+{% set pageName = "Cookies" %}
 
 {% block beforeContent %}
   {{ breadcrumb({
@@ -16,7 +14,7 @@
 
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1>Cookies on the NHS prototype kit</h1>
+      <h1>{{ pageName }}</h1>
 
       <p>Cookies are small files saved on your phone, tablet or computer when you visit a website.</p>
 

--- a/app/views/examples/branching/answer-no.html
+++ b/app/views/examples/branching/answer-no.html
@@ -2,9 +2,7 @@
 
 {% set mainClasses = 'nhsuk-main-wrapper--s' %}
 
-{% block pageTitle %}
-  Example - Branching - No
-{% endblock %}
+{% set pageName = "You answered no" %}
 
 {% block beforeContent %}
   {{ backLink({
@@ -19,7 +17,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
         <h1 class="nhsuk-heading-l">
-          You answered no
+          {{ pageName}}
         </h1>
 
         <p>

--- a/app/views/examples/branching/answer-yes.html
+++ b/app/views/examples/branching/answer-yes.html
@@ -2,9 +2,7 @@
 
 {% set mainClasses = 'nhsuk-main-wrapper--s' %}
 
-{% block pageTitle %}
-  Example - Branching - Yes
-{% endblock %}
+{% set pageName = "You answered yes" %}
 
 {% block beforeContent %}
   {{ backLink({
@@ -18,7 +16,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
         <h1 class="nhsuk-heading-l">
-          You answered yes
+          {{ pageName }}
         </h1>
 
         <p>

--- a/app/views/examples/branching/index.html
+++ b/app/views/examples/branching/index.html
@@ -1,8 +1,6 @@
 {% extends "layout.html" %}
 
-{% block pageTitle %}
-  Example - Branching
-{% endblock %}
+{% set pageName = "Example - Branching" %}
 
 {% block beforeContent %}
   {{ breadcrumb({

--- a/app/views/examples/passing-data/clear-data-success.html
+++ b/app/views/examples/passing-data/clear-data-success.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Example - passing data from page to page
-{% endblock %}
+{% set pageName = "Data reset" %}
 
 {% block beforeContent %}
   {{ breadcrumb({
@@ -22,7 +20,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1 class="nhsuk-heading-l">
-        Data reset
+        {{ pageName }}
       </h1>
 
       <p class="nhsuk-body">

--- a/app/views/examples/passing-data/clear-data.html
+++ b/app/views/examples/passing-data/clear-data.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Example - Clear data
-{% endblock %}
+{% set pageName = "Reset data" %}
 
 {% block beforeContent %}
   {{ breadcrumb({
@@ -20,7 +18,7 @@
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
-      <h1 class="nhsuk-heading-l">Reset data</h1>
+      <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
 
       <p class="nhsuk-body">This will reset all of the data entered in this session.</p>
 

--- a/app/views/examples/passing-data/passing-data-check-answers.html
+++ b/app/views/examples/passing-data/passing-data-check-answers.html
@@ -1,9 +1,7 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Example - passing data from page to page - step 5
-{% endblock %}
-
+{% set pageName = "Check your answers" %}
+  
 {% block beforeContent %}
   {{ breadcrumb({
     items: [
@@ -22,7 +20,7 @@
     <div class="nhsuk-grid-column-three-quarters">
 
       <h1>
-        Check your answers
+        {{ pageName }}
       </h1>
 
       <dl class="nhsuk-summary-list">

--- a/app/views/examples/passing-data/passing-data-confirmation.html
+++ b/app/views/examples/passing-data/passing-data-confirmation.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Example - passing data from page to page
-{% endblock %}
+{% set pageName = "Application complete" %}
 
 {% block beforeContent %}
   {{ breadcrumb({
@@ -22,7 +20,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       {{ panel({
-        titleText: "Application complete",
+        titleText: pageName,
         html: "Confirmation has been sent to you by email"
       }) }}
 

--- a/app/views/examples/passing-data/passing-data-question-conditions.html
+++ b/app/views/examples/passing-data/passing-data-question-conditions.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Conditions - Passing data example
-{% endblock %}
+{% set pageName = "Have you ever had any of these conditions?" %}
 
 {% block beforeContent %}
   {{ breadcrumb({
@@ -28,7 +26,7 @@
           name: "conditions",
           fieldset: {
             legend: {
-              text: "Have you ever had any of these conditions?",
+              text: pageName,
               classes: "nhsuk-fieldset__legend--l",
               isPageHeading: true
             }

--- a/app/views/examples/passing-data/passing-data-question-contact.html
+++ b/app/views/examples/passing-data/passing-data-question-contact.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  What is your name? - Passing data example
-{% endblock %}
+{% set pageName = "How would you prefer the GP to contact you?" %}
 
 {% block beforeContent %}
   {{ breadcrumb({
@@ -28,7 +26,7 @@
             name: "contact",
             fieldset: {
               legend: {
-                text: "How would you prefer the GP to contact you?",
+                text: pageName,
                 classes: "nhsuk-fieldset__legend--l",
                 isPageHeading: true
               }

--- a/app/views/examples/passing-data/passing-data-question-name.html
+++ b/app/views/examples/passing-data/passing-data-question-name.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  What is your name? - Passing data example
-{% endblock %}
+{% set pageName = "What is your name?" %}
 
 {% block beforeContent %}
   {{ breadcrumb({
@@ -25,7 +23,7 @@
         <fieldset class="nhsuk-fieldset">
           <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
             <h1 class="nhsuk-fieldset__heading">
-              What is your name?
+              {{ pageName }}
             </h1>
           </legend>
           <div class="nhsuk-form-group">

--- a/app/views/how-tos/adding-assets.html
+++ b/app/views/how-tos/adding-assets.html
@@ -2,9 +2,7 @@
 
 {% set currentSection = "Guides" %}
 
-{% block pageTitle %}
-  Adding CSS, JavaScript and images - NHS prototype kit
-{% endblock %}
+{% set pageName = "Adding CSS, JavaScript and images" %}
 
 {% block beforeContent %}
   {% include "how-tos/includes/breadcrumb.html" %}
@@ -16,7 +14,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        Adding CSS, JavaScript and images
+        {{ pageName }}
       </h1>
 
       <p>The prototype kit comes with standard NHS.UK frontend styles and components for you to use in your prototypes. However, if you need to add your own CSS (cascading style sheets), JavaScript or images, use the <code>/app/assets</code> folder.</p>

--- a/app/views/how-tos/branching.html
+++ b/app/views/how-tos/branching.html
@@ -2,9 +2,7 @@
 
 {% set currentSection = "Guides" %}
 
-{% block pageTitle %}
-  How to do branching - NHS prototype kit
-{% endblock %}
+{% set pageName = "Branching" %}
 
 {% block beforeContent %}
   {% include "how-tos/includes/breadcrumb.html" %}
@@ -15,7 +13,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-three-quarters">
 
-      <h1>Branching</h1>
+      <h1>{{ pageName }}</h1>
 
       <p class="nhsuk-lede-text">You can show a user different pages, depending on how they've answered a question.
 

--- a/app/views/how-tos/build-basic-prototype/_BASE.njk
+++ b/app/views/how-tos/build-basic-prototype/_BASE.njk
@@ -42,10 +42,6 @@
   "url": "ineligible"
 }  %}
 
-{% block pageTitle %}
- {{ pageTitle | default("Add title with 'pageTitle'")}} - {{sectionName}} - NHS prototype kit
-{% endblock %}
-
 {% block beforeContent %}
   {{ breadcrumb({
     items: [
@@ -73,7 +69,7 @@
       {% if not noCaption %}<span class="nhsuk-caption-xl">{{sectionName}}</span>{% endif %}
 
       <h1 class="nhsuk-heading-xl">
-        {{ pageTitle | default("Add title with 'pageTitle'") | safe }}
+        {{ pageName }}
       </h1>
 
       {% block makePrototype %}

--- a/app/views/how-tos/build-basic-prototype/branching.html
+++ b/app/views/how-tos/build-basic-prototype/branching.html
@@ -1,4 +1,4 @@
-{% set pageTitle = "Show different pages depending on user input (branching)" %}
+{% set pageName = "Show different pages depending on user input (branching)" %}
 {% set next = {
   "title": "Link your index page to your start page",
   "link": "link-index-page-start-page"

--- a/app/views/how-tos/build-basic-prototype/create-pages.html
+++ b/app/views/how-tos/build-basic-prototype/create-pages.html
@@ -1,4 +1,4 @@
-{% set pageTitle = "Create pages" %}
+{% set pageName = "Create pages" %}
 {% set next = {
   "title" : "Link your pages together",
   "link" : "link-pages-together"

--- a/app/views/how-tos/build-basic-prototype/index.html
+++ b/app/views/how-tos/build-basic-prototype/index.html
@@ -1,5 +1,6 @@
 {% set noCaption = true %}
-{% set pageTitle = "Build a basic prototype using the NHS prototype kit" %}
+
+{% set pageName = "Build a basic prototype using the NHS prototype kit" %}
 
 {% extends 'how-tos/build-basic-prototype/_BASE.njk' %}
 

--- a/app/views/how-tos/build-basic-prototype/let-user-change-answers.html
+++ b/app/views/how-tos/build-basic-prototype/let-user-change-answers.html
@@ -1,4 +1,4 @@
-{% set pageTitle = "Let the user change their answers" %}
+{% set pageName = "Let the user change their answers" %}
 {% set next = {
   "title": "Show different pages depending on user input",
   "link": "branching"

--- a/app/views/how-tos/build-basic-prototype/link-index-page-start-page.html
+++ b/app/views/how-tos/build-basic-prototype/link-index-page-start-page.html
@@ -1,5 +1,5 @@
 
-{% set pageTitle = "Link your index page to your start page" %}
+{% set pageName = "Link your index page to your start page" %}
 {% set prev = {
   "title": "Show different pages depending on user input",
   "link": "branching"

--- a/app/views/how-tos/build-basic-prototype/link-pages-together.html
+++ b/app/views/how-tos/build-basic-prototype/link-pages-together.html
@@ -1,4 +1,4 @@
-{% set pageTitle = "Link your pages together" %} {% set next = { "title" : "Use
+{% set pageName = "Link your pages together" %} {% set next = { "title" : "Use
 components from the design system" , "link" : "use-components" } %} {% set prev
 = { "title" : "Create pages" , "link" : "create-pages" } %} {% extends
 'how-tos/build-basic-prototype/_BASE.njk' %} {% block makePrototype %}

--- a/app/views/how-tos/build-basic-prototype/open-prototype-in-editor.html
+++ b/app/views/how-tos/build-basic-prototype/open-prototype-in-editor.html
@@ -1,4 +1,4 @@
-{% set pageTitle = "Open your prototype in your editor" %}
+{% set pageName = "Open your prototype in your editor" %}
 {% set next = { "title" : "Create pages" , "link" : "create-pages" } %}
 {% set prev = { "title" : "Get started" , "link" : "/how-tos/build-basic-prototype" } %}
 

--- a/app/views/how-tos/build-basic-prototype/show-users-answers.html
+++ b/app/views/how-tos/build-basic-prototype/show-users-answers.html
@@ -1,4 +1,4 @@
-{% set pageTitle = "Show the user's answers on the Check answers page" %} {%
+{% set pageName = "Show the user's answers on the Check answers page" %} {%
 set next = { "title" : "Let the user change their answers" , "link" :
 "let-user-change-answers" } %} {% set prev = { "title" : "Add a textarea to
 question 2" , "link" : "use-components-2" } %} {% extends

--- a/app/views/how-tos/build-basic-prototype/use-components-2.html
+++ b/app/views/how-tos/build-basic-prototype/use-components-2.html
@@ -1,4 +1,4 @@
-{% set pageTitle = "Add a textarea to question&nbsp;2" %}
+{% set pageName = "Add a textarea to question&nbsp;2" %}
 {% set next = {
   "title": "Show the user's answers on your Check answers page" ,
   "link": "show-users-answers"

--- a/app/views/how-tos/build-basic-prototype/use-components.html
+++ b/app/views/how-tos/build-basic-prototype/use-components.html
@@ -1,4 +1,4 @@
-{% set pageTitle = "Use components from the design system" %}
+{% set pageName = "Use components from the design system" %}
 {% set next = {
   "title": "Add a textarea to question 2" ,
   "link": "use-components-2"

--- a/app/views/how-tos/components.html
+++ b/app/views/how-tos/components.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  How to use components - NHS prototype kit
-{% endblock %}
+{% set pageName = "Using components" %}
 
 {% block beforeContent %}
   {% include "how-tos/includes/breadcrumb.html" %}
@@ -14,7 +12,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        Using components
+        {{ pageName }}
       </h1>
 
       <p class="nhsuk-lede-text">Components are reusable parts of the user interface, like buttons, text inputs and checkboxes.</p>

--- a/app/views/how-tos/git.html
+++ b/app/views/how-tos/git.html
@@ -2,9 +2,7 @@
 
 {% set currentSection = "Guides" %}
 
-{% block pageTitle %}
-  How to setup Git using the terminal - NHS prototype kit
-{% endblock %}
+{% set pageName = "Setting up Git using the terminal" %}
 
 {% block beforeContent %}
   {% include "how-tos/includes/breadcrumb.html" %}
@@ -16,7 +14,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        Setting up Git using the terminal
+        {{ pageName }}
       </h1>
 
       <p>Git is a type of version control software that tracks changes in your code. For example, when you edit a file, Git can help you determine exactly what changed, who changed it, and why.</p>

--- a/app/views/how-tos/github/_BASE.njk
+++ b/app/views/how-tos/github/_BASE.njk
@@ -2,11 +2,10 @@
 
 {% set currentSection = "Guides" %}
 
-{% block pageTitle %} {{pageTitle}} - Store code online using GitHub and GitHub Desktop - NHS prototype kit {% endblock %}
 {% block beforeContent
 %}
 
-{% if pageTitle == "Set up GitHub and GitHub Desktop"%}
+{% if pageName == "Set up GitHub and GitHub Desktop"%}
 {% include "how-tos/includes/breadcrumb.html" %}
 {% else %}
 {{ breadcrumb({ items: [ { href: "/", text: "Home" }, { href: "/how-tos",
@@ -21,8 +20,7 @@ GitHub and GitHub desktop" } ] })
   <div class="nhsuk-grid-column-three-quarters">
 
     <h1>
-      <span role="text">
-        {{pageTitle | default("pageTitle")}}
+      <span role="text">        
         <span class="nhsuk-caption-xl nhsuk-caption--bottom">
           <span class="nhsuk-u-visually-hidden">
           -
@@ -30,6 +28,7 @@ GitHub and GitHub desktop" } ] })
             Store code online with GitHub and GitHub Desktop
         </span>
       </span>
+      {{ pageName }}
     </h1>
 
     {{ contentsList({
@@ -37,29 +36,29 @@ GitHub and GitHub desktop" } ] })
         {
           href: "/how-tos/github/",
           text: "Overview",
-          current: ("true" if pageTitle and (pageTitle == "Overview") else '')
+          current: ("true" if pageName and (pageName == "Overview") else '')
         },
         {
           href: "/how-tos/github/setup-github-desktop",
           text: "Set up GitHub and GitHub Desktop",
-          current: ("true" if (pageTitle and  pageTitle == "Set up GitHub and GitHub Desktop") else '')
+          current: ("true" if (pageName and  pageName == "Set up GitHub and GitHub Desktop") else '')
         },
         {
           href: "/how-tos/github/store-new-prototype",
           text: "Store a new prototype on GitHub",
-          current: ("true" if (pageTitle and pageTitle == "Store a new prototype on GitHub") else '' )
+          current: ("true" if (pageName and pageName == "Store a new prototype on GitHub") else '' )
         }
         ,
         {
           href: "/how-tos/github/download-existing-prototype",
           text: "Download an existing prototype from GitHub",
-          current: ("true" if (pageTitle and pageTitle == "Download an existing prototype from GitHub") else '' )
+          current: ("true" if (pageName and pageName == "Download an existing prototype from GitHub") else '' )
         }
         ,
         {
           href: "/how-tos/github/collaborate",
           text: "Collaborate on a prototype",
-          current: ("true" if (pageTitle and pageTitle == "Collaborate on a prototype") else '')
+          current: ("true" if (pageName and pageName == "Collaborate on a prototype") else '')
         }
       ]
     }) }}
@@ -72,14 +71,14 @@ GitHub and GitHub desktop" } ] })
     {% endblock %}
 
 
-{% if pageTitle == "Overview" %}{# first page #}
+{% if pageName == "Overview" %}{# first page #}
 
 {{ pagination({
   nextUrl: "/how-tos/github/setup-github-desktop",
   nextPage: "Set up GitHub and GitHub Desktop"
 }) }}
 
-{% elif pageTitle == "Set up GitHub and GitHub Desktop" %}
+{% elif pageName == "Set up GitHub and GitHub Desktop" %}
 {{ pagination({
     previousUrl: "/how-tos/github/index",
     previousPage: "Overview",
@@ -87,7 +86,7 @@ GitHub and GitHub desktop" } ] })
     nextPage: "Store a new prototype on GitHub"
 }) }}
 
-{% elif pageTitle == "Store a new prototype on GitHub" %}
+{% elif pageName == "Store a new prototype on GitHub" %}
 {{ pagination({
     previousUrl: "/how-tos/github/setup-github-desktop",
     previousPage: "Set up GitHub and GitHub Desktop",
@@ -95,7 +94,7 @@ GitHub and GitHub desktop" } ] })
     nextPage: "Download an existing prototype from GitHub"
 }) }}
 
-{% elif pageTitle == "Download an existing prototype from GitHub" %}
+{% elif pageName == "Download an existing prototype from GitHub" %}
 {{ pagination({
     previousUrl: "/how-tos/github/store-new-prototype",
     previousPage: "Store a new prototype on GitHub",

--- a/app/views/how-tos/github/collaborate.html
+++ b/app/views/how-tos/github/collaborate.html
@@ -1,4 +1,4 @@
-{% set pageTitle = "Collaborate on a prototype" %}
+{% set pageName = "Collaborate on a prototype" %}
 {% extends "how-tos/github/_BASE.njk" %} 
 {% block hub %}
 

--- a/app/views/how-tos/github/download-existing-prototype.html
+++ b/app/views/how-tos/github/download-existing-prototype.html
@@ -1,4 +1,4 @@
-{% set pageTitle = "Download an existing prototype from GitHub" %}
+{% set pageName = "Download an existing prototype from GitHub" %}
 {% extends "how-tos/github/_BASE.njk" %} 
 {% block hub %}
 

--- a/app/views/how-tos/github/index.html
+++ b/app/views/how-tos/github/index.html
@@ -1,4 +1,4 @@
-{% set pageTitle = "Overview" %}
+{% set pageName = "Overview" %}
 {% extends "how-tos/github/_BASE.njk" %} 
 {% block hub %}
 

--- a/app/views/how-tos/github/setup-github-desktop.html
+++ b/app/views/how-tos/github/setup-github-desktop.html
@@ -1,4 +1,4 @@
-{% set pageTitle = "Set up GitHub and GitHub Desktop" %}
+{% set pageName = "Set up GitHub and GitHub Desktop" %}
 {% extends "how-tos/github/_BASE.njk" %} 
 {% block hub %}
 

--- a/app/views/how-tos/github/store-new-prototype.html
+++ b/app/views/how-tos/github/store-new-prototype.html
@@ -1,4 +1,4 @@
-{% set pageTitle = "Store a new prototype on GitHub" %}
+{% set pageName = "Store a new prototype on GitHub" %}
 {% extends "how-tos/github/_BASE.njk" %}
 {% block hub %}
     <p>

--- a/app/views/how-tos/making-pages.html
+++ b/app/views/how-tos/making-pages.html
@@ -2,9 +2,7 @@
 
 {% set currentSection = "Guides" %}
 
-{% block pageTitle %}
-  How to make pages - NHS prototype kit
-{% endblock %}
+{% set pageName = "Making pages" %}
 
 {% block beforeContent %}
   {% include "how-tos/includes/breadcrumb.html" %}
@@ -16,7 +14,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        Making pages
+        {{ pageName }}
       </h1>
 
       <p class="nhsuk-lede-text">Use your HTML text editor to make pages.</p>

--- a/app/views/how-tos/passing-data-page.html
+++ b/app/views/how-tos/passing-data-page.html
@@ -2,9 +2,7 @@
 
 {% set currentSection = "Guides" %}
 
-{% block pageTitle %}
-  How to pass data page to page - NHS prototype kit
-{% endblock %}
+{% set pageName = "Passing data page to page" %}
 
 {% block beforeContent %}
   {% include "how-tos/includes/breadcrumb.html" %}
@@ -14,7 +12,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1>Passing data page to page</h1>
+      <h1>{{ pageName }}</h1>
 
       <p>The kit stores data from all answers that users give in a prototype. This lets you use or show the answers later.</p>
 

--- a/app/views/how-tos/publish-your-prototype-online.html
+++ b/app/views/how-tos/publish-your-prototype-online.html
@@ -2,9 +2,7 @@
 
 {% set currentSection = "Guides" %}
 
-{% block pageTitle %}
-  Publish your prototype online - NHS prototype kit
-{% endblock %}
+{% set pageName = "Publish your prototype online" %}
 
 {% block beforeContent %}
   {% include "how-tos/includes/breadcrumb.html" %}
@@ -15,7 +13,7 @@
 
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1>Publish your prototype online</h1>
+      <h1>{{ pageName }}</h1>
 
       <p>Publishing your prototype online means you can share it with others and test it with users.</p>
 

--- a/app/views/how-tos/set-page-titles.html
+++ b/app/views/how-tos/set-page-titles.html
@@ -2,9 +2,7 @@
 
 {% set currentSection = "Guides" %}
 
-{% block pageTitle %}
-  Set page titles - NHS prototype kit
-{% endblock %}
+{% set pageName = "Set page titles" %}
 
 {% block beforeContent %}
   {% include "how-tos/includes/breadcrumb.html" %}
@@ -14,7 +12,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1>Set page titles</h1>
+      <h1>{{ pageName }}</h1>
 
       {{ insetText({
         text: "This feature requires version 6.3.0 of the NHS prototype kit or above."

--- a/app/views/how-tos/switching-from-govuk-prototype-kit.html
+++ b/app/views/how-tos/switching-from-govuk-prototype-kit.html
@@ -2,12 +2,13 @@
 
 {% set currentSection = "Guides" %}
 
-{% block pageTitle %} Switching from the GOV.UK
-prototype kit - NHS prototype kit {% endblock %} {% block beforeContent %} {%
+{% set pageName "Switching from the GOV.UK prototype kit" %} 
+
+{% block beforeContent %} {%
 include "how-tos/includes/breadcrumb.html" %} {% endblock %} {% block content %}
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-two-thirds">
-    <h1 class="nhsuk-heading-xl">Switching from the GOV.UK Prototype Kit</h1>
+    <h1 class="nhsuk-heading-xl">{{ pageName }}</h1>
 
     <p>
       If you have learned how to use the

--- a/app/views/how-tos/updating-the-kit.html
+++ b/app/views/how-tos/updating-the-kit.html
@@ -2,9 +2,7 @@
 
 {% set currentSection = "Guides" %}
 
-{% block pageTitle %}
-  Updating the kit - NHS prototype kit
-{% endblock %}
+{% set pageName = "Updating the kit" %}
 
 {% block beforeContent %}
   {% include "how-tos/includes/breadcrumb.html" %}
@@ -16,7 +14,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        Updating the kit
+        {{ pageName }}
       </h1>
 
       {{ insetText({

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -1,9 +1,5 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  NHS prototype kit
-{% endblock %}
-
 {% block header %}
   {{ super() }}
 

--- a/app/views/install/advanced.html
+++ b/app/views/install/advanced.html
@@ -2,9 +2,7 @@
 
 {% set currentSection = "Get started" %}
 
-{% block pageTitle %}
-  Advanced install guide - NHS prototype kit
-{% endblock %}
+{% set pageName = "Advanced install guide" %}
 
 {% block beforeContent %}
   {{ breadcrumb({
@@ -24,7 +22,7 @@
 
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1>Advanced install guide</h1>
+      <h1>{{ pageName }}</h1>
 
       <p>The kit is built on the <a href="http://expressjs.com/" rel="noopener">Express</a> framework, and uses <a href="https://github.com/nhsuk/nhsuk-frontend" rel="noopener">NHS.UK frontend</a>.</p>
 

--- a/app/views/install/check-it-works.html
+++ b/app/views/install/check-it-works.html
@@ -2,9 +2,7 @@
 
 {% set currentSection = "Get started" %}
 
-{% block pageTitle %}
-  Check it works - NHS prototype kit
-{% endblock %}
+{% set pageName = "Check it works" %}
 
 {% block beforeContent %}
   {{ breadcrumb({

--- a/app/views/install/codespaces/create-a-codespace.html
+++ b/app/views/install/codespaces/create-a-codespace.html
@@ -2,9 +2,7 @@
 {% set current_step = '1' %}
 {% set currentSection = "Get started" %}
 
-{% block pageTitle %}
-  Create a codespace - NHS prototype kit
-{% endblock %}
+{% set pageName = "Create a codespace" %}
 
 {% extends 'install/codespace.html' %}
 

--- a/app/views/install/codespaces/index.html
+++ b/app/views/install/codespaces/index.html
@@ -2,9 +2,7 @@
 
 {% set currentSection = "Get started" %}
 
-{% block pageTitle %}
-  Install and use the kit with your web browser - NHS prototype kit
-{% endblock %}
+{% set pageName = "Install and use the kit with your web browser" %}
 
 {% block beforeContent %}
   {{ breadcrumb({
@@ -25,7 +23,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuk-heading-xl">Install and use the kit with your web browser</h1>
+      <h1 class="nhsuk-heading-xl">{{ pageName }}</h1>
 
       <p class="nhsuk-body-l">If you cannot install the kit on your computer (for example, because you are not allowed to install Node.js) you can use an online service to edit and run code using your web browser.</p>
 

--- a/app/views/install/codespaces/working-with-codespaces.html
+++ b/app/views/install/codespaces/working-with-codespaces.html
@@ -2,9 +2,7 @@
 {% set current_step = 2 %}
 {% set currentSection = "Get started" %}
 
-{% block pageTitle %}
-  Editing the kit with Codespaces -  NHS prototype kit
-{% endblock %}
+{% set pageName = "Editing the kit with Codespaces" %}
 
 {% extends 'install/codespace.html' %}
 

--- a/app/views/install/download.html
+++ b/app/views/install/download.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Download and decide where to keep your prototypes - NHS prototype kit
-{% endblock %}
+{% set pageName = "Download and decide where to keep your prototypes" %}
 
 {% set currentSection = "Get started" %}
 

--- a/app/views/install/mac-or-windows.html
+++ b/app/views/install/mac-or-windows.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Mac or Windows - NHS prototype kit
-{% endblock %}
+{% set pageName = "Mac or Windows" %}
 
 {% set currentSection = "Get started" %}
 

--- a/app/views/install/nhs-england-windows-laptops.html
+++ b/app/views/install/nhs-england-windows-laptops.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Set up the prototype kit on an NHS England Windows laptop - NHS prototype kit
-{% endblock %}
+{% set pageName = "Set up the prototype kit on an NHS England Windows laptop" %}
 
 {% set currentSection = "Get started" %}
 
@@ -25,7 +23,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuk-heading-l">Set up the prototype kit on an NHS England Windows laptop</h1>
+      <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
 
       <p>If you have a Windows laptop issued by NHS England corporate IT, before you start any of the install guides you will need to:</p>
 

--- a/app/views/install/node.html
+++ b/app/views/install/node.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Install Node - NHS prototype kit
-{% endblock %}
+{% set pageName = "Install Node" %}
 
 {% set currentSection = "Get started" %}
 

--- a/app/views/install/open.html
+++ b/app/views/install/open.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Go to your prototype- NHS prototype kit
-{% endblock %}
+{% set pageName = "Go to your prototype" %}
 
 {% set currentSection = "Get started" %}
 

--- a/app/views/install/run.html
+++ b/app/views/install/run.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Run the kit - NHS prototype kit
-{% endblock %}
+{% set pageName = "Run the kit" %}
 
 {% set currentSection = "Get started" %}
 

--- a/app/views/install/setup.html
+++ b/app/views/install/setup.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Setup the kit - NHS prototype kit
-{% endblock %}
+{% set pageName = "Setup the kit" %}
 
 {% set currentSection = "Get started" %}
 

--- a/app/views/install/simple.html
+++ b/app/views/install/simple.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Install guide - NHS prototype kit
-{% endblock %}
+{% set pageName = "Install guide" %}
 
 {% set currentSection = "Get started" %}
 
@@ -22,7 +20,7 @@
 {% block content %}
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-two-thirds">
-    <h1>Install guide</h1>
+    <h1>{{ pageName }}</h1>
 
     <p class="nhsuk-lede-text">
       To start making prototypes you need to setup the right tools to make the

--- a/app/views/install/terminal.html
+++ b/app/views/install/terminal.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Terminal - NHS prototype kit
-{% endblock %}
+{% set pageName = "Terminal" %}
 
 {% set currentSection = "Get started" %}
 
@@ -31,7 +29,7 @@
 
       <h1>
         <span class="nhsuk-caption-l">Step 1 of 8{{[":", installEnvironment ] | join(" ") if installEnvironment }}</span>
-        {% block branchingHeader %}Terminal{% endblock %}
+        {% block branchingHeader %}{{ pageName }}{% endblock %}
       </h1>
 
       {% block branchingContent %}

--- a/app/views/install/text-editor.html
+++ b/app/views/install/text-editor.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  HTML text editor - NHS prototype kit
-{% endblock %}
+{% set pageName = "HTML text editor" %}
 
 {% set currentSection = "Get started" %}
 
@@ -31,7 +29,7 @@
 
       <h1>
         <span class="nhsuk-caption-l">Step 3 of 8{{[":", installEnvironment ] | join(" ") if installEnvironment }}</span>
-        HTML text editor
+        {{ pageName }}
       </h1>
 
       <p class="nhsuk-lede-text">You'll need an HTML text editor to edit and make changes to your prototype.</p>

--- a/app/views/install/windows/terminal.html
+++ b/app/views/install/windows/terminal.html
@@ -3,9 +3,7 @@
 
 {% extends "install/terminal.html" %}
 
-{% block pageTitle %}
-  NHS prototype kit - Command Prompt
-{% endblock %}
+{% set pageName = "Command Prompt" %}
 
 {% block branchingContent %}
   <p class="nhsuk-lede-text">The first thing you need to do is open the <strong>Command Prompt</strong> on your Windows machine.</p>

--- a/app/views/page-templates.html
+++ b/app/views/page-templates.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Page templates - NHS prototype kit
-{% endblock %}
+{% set pageName = "Page templates" %}
 
 {% block beforeContent %}
   {{ breadcrumb({
@@ -16,7 +14,7 @@
 
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1 class="nhsuk-heading-xl">Page templates</h1>
+      <h1 class="nhsuk-heading-xl">{{ pageName }}</h1>
 
       <p>You can find some example page templates in <a href="https://service-manual.nhs.uk/design-system/patterns">patterns section of the NHS service manual</a>.</p>
 

--- a/app/views/templates/nhsuk-coronavirus-hub.html
+++ b/app/views/templates/nhsuk-coronavirus-hub.html
@@ -3,7 +3,7 @@
 <!-- some custom css padding for the coronavirus hub page -->
 {% set mainClasses = 'nhsuk-u-padding-top-0' %}
 
-{% block pageTitle %}
+{% set pageTitle %}
   Coronavirus (COVID-19) - NHS
 {% endblock %}
 

--- a/app/views/whats-new/updates.html
+++ b/app/views/whats-new/updates.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Updates - NHS prototype kit
-{% endblock %}
+{% set pageName = "Updates" %}
 
 {% block beforeContent %}
   {{ breadcrumb({
@@ -15,7 +13,7 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1>Updates</h1>
+      <h1>{{ pageName }}</h1>
 
       <p class="nhsuk-lede-text">Changes made in each major and minor version.</p>
 


### PR DESCRIPTION
This improves consistency of the `<title>` tag suffix, and is what we now guide users of the NHS Prototype kit to do in our own guide (since  6.3.0).