### PR TITLE
Improve the Making pages guide

### DIFF
--- a/app/views/how-tos/making-pages.html
+++ b/app/views/how-tos/making-pages.html
@@ -29,7 +29,7 @@
 
       <h2>Specifying a layout</h2>
 
-      <p>Each page you create will need to specify which layout it uses. Otherwise you’ll will get white background with no header or footer!</p>
+      <p>Each page you create will need to specify which layout it uses. Otherwise you’ll get a white background with no header or footer!</p>
 
       <p>To use the standard layout that comes with the prototype kit, add this line to the top of each file:</p>
 

--- a/app/views/how-tos/making-pages.html
+++ b/app/views/how-tos/making-pages.html
@@ -37,7 +37,7 @@
 {% extends "layout.html" %}
       {% endraw %}{% endcall %}
 
-      <h2>Using sub-folders</h2>
+      <h2>Using subfolders</h2>
 
       <p>The kit allows you add pages into sub-folders within <code>app/views</code>.</p>
 

--- a/app/views/how-tos/making-pages.html
+++ b/app/views/how-tos/making-pages.html
@@ -17,29 +17,42 @@
         {{ pageName }}
       </h1>
 
-      <p class="nhsuk-lede-text">Use your HTML text editor to make pages.</p>
+      <p class="nhsuk-lede-text">Use your code editor to make pages.</p>
 
-      <p>Create all your HTML pages in the <strong>/app/views</strong> folder.</p>
+      <p>Create all your pages in the <code>/app/views</code> folder.</p>
 
-      <p>All pages need the <strong>.html</strong> extension.</p>
+      <p>The file names must end in <code>.html</code> – this is called the file extension.</p>
 
-      <p>Pages within <strong>/app/views</strong> will be automatically available in your web browser.</p>
+      <p> It’s a good idea to name the files using a lowercase version of the page title, with spaces replaced by hyphens. For example, <code>find-a-gap.html</code>.</p>
 
-      <p>For example, if you create a page called <strong>contact.html</strong> and then go to <strong>localhost:3000/contact</strong> in your browser, you will see that page.</p>
+      <p>The pages you create are automatically viewable in your browser at the path that matches the file name. For example, if you create a page called <code>contact.html</code> and go to <code>http://localhost:3000/contact</code> in your browser, you will see that page.</p>
 
-      <img class="app-img-guide" alt="Screenshot of creating a new page" src="/images/page-example.png" />
+      <h2>Specifying a layout</h2>
 
-      <h2>Using folders</h2>
+      <p>Each page you create will need to specify which layout it uses. Otherwise you’ll likely get a plain white background with no header or footer!</p>
 
-      <p>The kit allows you add pages into folders.</p>
+      <p>To use the standard layout that comes with the prototype kit, add this line to the top of each view file:</p>
 
-      <p>For example, you can make the page <strong>views/medicines/ibuprofen.html</strong>, and then view the page by going to <strong>localhost:3000/medicines/ibuprofen</strong>.</p>
+      {% call codeSnippet({ language: "js" }) %}{% raw %}
+{% extends "layout.html" %}
+      {% endraw %}{% endcall %}
 
-      <img class="app-img-guide" alt="Screenshot of creating a folder for new pages" src="/images/folder-example.png" />
+      <h2>Using sub-folders</h2>
 
-      <h2>Page templates</h2>
+      <p>The kit allows you add pages into sub-folders within <code>app/views</code>.</p>
 
-      <p>Copy and paste <a href="/page-templates">page templates</a> into your project.</p>
+      <p>For example, you can create a page at <code>app/views/medicines/ibuprofen.html</code>, and then view the page by going to <code>http://localhost:3000/medicines/ibuprofen</code>.</p>
+
+      <h2>Index views</h2>
+
+      <p>If a view file is named <code>index.html</code> it is special, and can be viewed in your browser without specifying the full name.</p>
+
+      <p>The file at <code>app/views/index.html</code> is your ‘home page’, and can be viewed at <code>http://localhost:3000/</code>.</p>
+
+      <p>You can also add views named <code>index.html</code> within sub-folders.</p>
+
+      <p>For example, a view named <code>app/views/medicines/index.html</code> can be viewed at <code>http://localhost:3000/medicines/</code>.</p>
+
     </div>
 
   </div>

--- a/app/views/how-tos/making-pages.html
+++ b/app/views/how-tos/making-pages.html
@@ -39,7 +39,7 @@
 
       <h2>Using subfolders</h2>
 
-      <p>The kit allows you add pages into sub-folders within <code>app/views</code>.</p>
+      <p>The kit allows you add pages into subfolders within <code>app/views</code>.</p>
 
       <p>For example, you can create a page at <code>app/views/medicines/ibuprofen.html</code>, and then view the page by going to <code>http://localhost:3000/medicines/ibuprofen</code>.</p>
 

--- a/app/views/how-tos/making-pages.html
+++ b/app/views/how-tos/making-pages.html
@@ -25,7 +25,7 @@
 
       <p>It’s a good idea to name the files using a shortened, lowercase version of the page title, with spaces replaced by hyphens. For example, <code>find-a-gp.html</code>.</p>
 
-      <p>The pages you create are automatically viewable in your browser at the URL that matches the file name. For example, if you create a page called <code>contact.html</code> and go to <code>http://localhost:3000/contact</code> in your browser, you will see that page.</p>
+      <p>The pages you create are automatically viewable in your browser at the URL that matches the file name. For example, if you go to <code>http://localhost:3000/contact</code> in your browser, you will see the <code>contact.html</code> page.</p>
 
       <h2>Specifying a layout</h2>
 

--- a/app/views/how-tos/making-pages.html
+++ b/app/views/how-tos/making-pages.html
@@ -47,7 +47,7 @@
 
       <p>If a file is named <code>index.html</code> it is special, and can be viewed in your browser without specifying the full name.</p>
 
-      <p>The file at <code>app/views/index.html</code> is your ‘home page’, and can be viewed at <code>http://localhost:3000/</code>.</p>
+      <p>The file at <code>app/views/index.html</code> is your ‘home page’, and can be viewed at <code>http://localhost:3000</code>.</p>
 
       <p>You can also add files named <code>index.html</code> within sub-folders.</p>
 

--- a/app/views/how-tos/making-pages.html
+++ b/app/views/how-tos/making-pages.html
@@ -31,7 +31,7 @@
 
       <p>Each page you create will need to specify which layout it uses. Otherwise you’ll likely get a plain white background with no header or footer!</p>
 
-      <p>To use the standard layout that comes with the prototype kit, add this line to the top of each view file:</p>
+      <p>To use the standard layout that comes with the prototype kit, add this line to the top of each file:</p>
 
       {% call codeSnippet({ language: "js" }) %}{% raw %}
 {% extends "layout.html" %}
@@ -43,15 +43,15 @@
 
       <p>For example, you can create a page at <code>app/views/medicines/ibuprofen.html</code>, and then view the page by going to <code>http://localhost:3000/medicines/ibuprofen</code>.</p>
 
-      <h2>Index views</h2>
+      <h2>Index pages</h2>
 
-      <p>If a view file is named <code>index.html</code> it is special, and can be viewed in your browser without specifying the full name.</p>
+      <p>If a file is named <code>index.html</code> it is special, and can be viewed in your browser without specifying the full name.</p>
 
       <p>The file at <code>app/views/index.html</code> is your ‘home page’, and can be viewed at <code>http://localhost:3000/</code>.</p>
 
-      <p>You can also add views named <code>index.html</code> within sub-folders.</p>
+      <p>You can also add files named <code>index.html</code> within sub-folders.</p>
 
-      <p>For example, a view named <code>app/views/medicines/index.html</code> can be viewed at <code>http://localhost:3000/medicines/</code>.</p>
+      <p>For example, a file named <code>app/views/medicines/index.html</code> can be viewed at <code>http://localhost:3000/medicines/</code>.</p>
 
     </div>
 

--- a/app/views/how-tos/making-pages.html
+++ b/app/views/how-tos/making-pages.html
@@ -29,7 +29,7 @@
 
       <h2>Specifying a layout</h2>
 
-      <p>Each page you create will need to specify which layout it uses. Otherwise you’ll likely get a plain white background with no header or footer!</p>
+      <p>Each page you create will need to specify which layout it uses. Otherwise you’ll will get white background with no header or footer!</p>
 
       <p>To use the standard layout that comes with the prototype kit, add this line to the top of each file:</p>
 

--- a/app/views/how-tos/making-pages.html
+++ b/app/views/how-tos/making-pages.html
@@ -25,7 +25,7 @@
 
       <p> It’s a good idea to name the files using a lowercase version of the page title, with spaces replaced by hyphens. For example, <code>find-a-gap.html</code>.</p>
 
-      <p>The pages you create are automatically viewable in your browser at the path that matches the file name. For example, if you create a page called <code>contact.html</code> and go to <code>http://localhost:3000/contact</code> in your browser, you will see that page.</p>
+      <p>The pages you create are automatically viewable in your browser at the URL that matches the file name. For example, if you create a page called <code>contact.html</code> and go to <code>http://localhost:3000/contact</code> in your browser, you will see that page.</p>
 
       <h2>Specifying a layout</h2>
 


### PR DESCRIPTION
This attempts to make improvements by explaining that:

* pages need to start by extending a layout
* sub-folders can be used
* how `index.html` pages are special

It also switches from using `<strong>` to using `<code>` for code and file references.

The 2 images have been removed as they’re out of date, but could be replaced if needed (maybe not though)?