### PR TITLE
Remove session data defaults

### DIFF
--- a/app.js
+++ b/app.js
@@ -118,21 +118,6 @@ function checkFiles() {
 // initial checks
 checkFiles();
 
-// Create template session data defaults file if it doesn't exist
-const dataDirectory = path.join(__dirname, '/app/data');
-const sessionDataDefaultsFile = path.join(dataDirectory, '/session-data-defaults.js');
-const sessionDataDefaultsFileExists = fs.existsSync(sessionDataDefaultsFile);
-
-if (!sessionDataDefaultsFileExists) {
-  console.log('Creating session data defaults file'); // eslint-disable-line no-console
-  if (!fs.existsSync(dataDirectory)) {
-    fs.mkdirSync(dataDirectory);
-  }
-
-  fs.createReadStream(path.join(__dirname, '/lib/template.session-data-defaults.js'))
-    .pipe(fs.createWriteStream(sessionDataDefaultsFile));
-}
-
 // Local variables
 app.use(locals(config));
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,3 @@
-// NPM dependencies
-const path = require('path');
-
 // Require core and custom filters, merges to one object
 // and then add the methods to Nunjucks environment
 const coreFilters = require('./core_filters');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -94,25 +94,13 @@ const storeData = function (input, data) { /* eslint-disable-line func-names */
   });
 };
 
-// Get session default data from file
-let sessionDataDefaults = {};
-
-const sessionDataDefaultsFile = path.join(__dirname, '../app/data/session-data-defaults.js');
-
-try {
-  /* eslint-disable-next-line */
-  sessionDataDefaults = require(sessionDataDefaultsFile);
-} catch (e) {
-  console.error('Could not load the session data defaults from app/data/session-data-defaults.js. Might be a syntax error?'); // eslint-disable-line no-console
-}
-
 // Middleware - store any data sent in session, and pass it to all views
 exports.autoStoreData = function (req, res, next) { /* eslint-disable-line func-names */
   if (!req.session.data) {
     req.session.data = {};
   }
 
-  req.session.data = { ...sessionDataDefaults, ...req.session.data };
+  req.session.data = { ...req.session.data };
 
   storeData(req.body, req.session.data);
   storeData(req.query, req.session.data);


### PR DESCRIPTION
This functionality was inherited from the kit itself, but isn’t needed for the documentation website.