### PR TITLE
Add page about the training course

### DIFF
--- a/app/training-course.md
+++ b/app/training-course.md
@@ -4,13 +4,13 @@ title: Training course
 description: Learn how to use the NHS prototype kit on our in-person 1‑day training course.
 ---
 
-The course is an in-person alternative to our [online tutorial](/guides/build-basic-prototype/) and covers: 
+The course is an in-person alternative to our [online tutorial](/guides/build-basic-prototype/) and covers:
 
-* setting up a new prototype using GitHub 
-* using a code editor like Visual Studio 
-* an introduction to HTML
-* how to use Nunjucks components from the NHS design system 
-* adding 'branching' to a service using using Javascript
+- setting up a new prototype using GitHub
+- using a code editor like Visual Studio
+- an introduction to HTML
+- how to use Nunjucks components from the NHS design system
+- adding 'branching' to a service using using Javascript
 
 The course is run regularly and is open to anyone who works for the NHS, including interaction designers, content designers and other roles.
 
@@ -18,4 +18,4 @@ Priority is given to NHS England employees.
 
 [Register your interest in attending the course](https://forms.office.com/pages/responsepage.aspx?id=slTDN7CF9UeyIge0jXdO4yDQZMYZ1-lDqfmR_EKWYuRURDhHMktOSkk5VUFGUVJDOVk1UkFLRUxRTS4u&route=shorturl)
 
-We will contact you when a place becomes available. 
+We will contact you when a place becomes available.


### PR DESCRIPTION
This would make the training course a little more discoverable, and give us a place to send people who are interested in signing up.

Not yet decided where we’d link to this page from. Possibly makes sense to do it from the "Get started" index page?