### PR TITLE
Add a guide for updating to version 8

### DIFF
--- a/app/install/updating-to-version-8.md
+++ b/app/install/updating-to-version-8.md
@@ -33,8 +33,6 @@ In the `dependencies` section, update the contents to:
 }
 ```
 
-
-
 Update the `scripts` section of your `package.json` file to:
 
 ```json


### PR DESCRIPTION
This adds a new (initially hidden) page for upgrading to the beta version 8 of the prototype kit.

The update is tricky as it involves manual edits and deletions, but future updates will be a lot easier.