### PR TITLE
Add section about editing locals.js in update guide

### DIFF
--- a/app/install/updating-to-version-8.md
+++ b/app/install/updating-to-version-8.md
@@ -41,7 +41,7 @@ Update the `scripts` section of your `package.json` file to:
 }
 ```
 
-### 2. Delete these folders and files
+### 3. Delete these folders and files
 
 Delete these folders:
 
@@ -55,7 +55,29 @@ Delete these files:
 - `gulpfile.js`
 - `app/assets/javascript/auto-store-data.js` (if present)
 
-### 3. Edit your `app.js` file
+### 4. Edit your `locals.js` file
+
+Update the file to this:
+
+```js
+module.exports = function(req, res, next) {
+
+  // You can set any additional local variables here.
+  // These will be made available to any views
+  //
+  // For example:
+  //
+  // req.locals.organisationName = 'NHS'
+
+  next()
+}
+```
+
+If you had previously edited the file to set any local variables, copy the relevant lines back in to the file, above the `next()` line.
+
+You no longer need to set the `serviceName` variable as this is done automatically.
+
+### 5. Edit your `app.js` file
 
 Replace the entire contents of it with this:
 
@@ -96,7 +118,7 @@ for (const [name, filter] of Object.entries(filters())) {
 prototype.start(port)
 ```
 
-### 5. Run `npm install` in your terminal
+### 6. Run `npm install` in your terminal
 
 The install may take up to a minute.
 
@@ -113,7 +135,7 @@ run `npm fund` for details
 found 0 vulnerabilities
 ```
 
-### 6. Edit your layout file
+### 7. Edit your layout file
 
 In your `app/layout.html` file, update the the last part of the file which references `bodyEnd` to this:
 
@@ -130,7 +152,7 @@ In your `app/layout.html` file, update the the last part of the file which refer
 
 If you have added any custom frontend JavaScript to your prototype, you will need to add references to it here too.
 
-### 7. Start your local server
+### 8. Start your local server
 
 In your terminal, enter: <kbd>npm start</kbd>
 


### PR DESCRIPTION
This file needs to be updated, as it is no longer called with the `config` object, and is instead treated as a regular middleware function.

Also,`serviceName` no longer needs to be set as the kit does this separately.

<img width="841" height="617" alt="Screenshot 2026-01-09 at 13 23 12" src="https://github.com/user-attachments/assets/51cb8dba-d73e-4298-ab8f-f18d33de02ba" />
