### PR TITLE
Add suggestion to remove devDependencies

### DIFF
--- a/app/install/updating-to-version-8.md
+++ b/app/install/updating-to-version-8.md
@@ -33,6 +33,13 @@ In the `dependencies` section, update the contents to:
 }
 ```
 
+In the `devDependencies` section, update the contents to:
+
+```json
+"devDependencies": {
+}
+```
+
 Update the `scripts` section of your `package.json` file to:
 
 ```json


### PR DESCRIPTION
Most users aren't using code linting (previously it was set up to ignore everything in `app` and only check the code in `lib`) so these can be removed.

(If users want to do code linting on their prototype code, they can set this up themselves).