### PR TITLE
Update v8 update guide

### DIFF
--- a/app/install/updating-to-version-8.md
+++ b/app/install/updating-to-version-8.md
@@ -170,12 +170,14 @@ You should have a layout file named `app/layout.html`.
 In that file, update the lines which references `block head` to this:
 
 {% raw %}
+
 ```njk
 {% block head %}
   <!-- Add your custom CSS or Sass in /app/assets/sass/main.scss -->
   <link href="/main.css" rel="stylesheet">
 {% endblock %}
 ```
+
 {% endraw %}
 
 Update the section which references `block bodyEnd` to this:


### PR DESCRIPTION
Forgot to mention also needing to change the path to the CSS...

New lines added:

<img width="778" height="236" alt="Screenshot 2026-01-16 at 14 51 38" src="https://github.com/user-attachments/assets/a677d3dd-e745-4447-9740-7a45ddacc59d" />

Thanks to @jolumley-nhs for testing the upgrade guide and reporting this!