### PR TITLE
Mention NHS App frontend in update guide

### DIFF
--- a/app/install/updating-to-version-8.md
+++ b/app/install/updating-to-version-8.md
@@ -160,7 +160,6 @@ prototype.start(port)
 > ]
 > ```
 
-
 ### 7. Run `npm install` in your terminal
 
 The install may take up to a minute.


### PR DESCRIPTION
For anyone using NHS App frontend as well as NHS frontend, there are some additional steps to take. This documents these, using Inset text.

The 2 extra steps are:

## 1. keeping the repo as a dependency:

<img width="801" height="450" alt="Screenshot 2026-01-16 at 15 35 30" src="https://github.com/user-attachments/assets/a08ca51a-4997-4720-be92-166d7aa9f337" />

## 2. adding the view path (for the macros):

<img width="793" height="328" alt="Screenshot 2026-01-16 at 15 36 14" src="https://github.com/user-attachments/assets/e0528975-08ba-4a44-80d7-fb1eca5919ef" />


