### PR TITLE
Update v8 update guide for beta.9

### DIFF
--- a/app/install/updating-to-version-8.md
+++ b/app/install/updating-to-version-8.md
@@ -130,14 +130,16 @@ const viewsPath = [
   'app/views/'
 ]
 
+const entryPoints = [
+  'app/assets/sass/main.scss',
+  'app/assets/javascript/*.js'
+]
+
 async function init() {
   const prototype = await NHSPrototypeKit.init({
     serviceName: config.serviceName,
     buildOptions: {
-      entryPoints: [
-        'app/assets/sass/main.scss',
-        'app/assets/javascript/*.js'
-      ]
+      entryPoints: entryPoints
     },
     viewsPath,
     routes,


### PR DESCRIPTION
This updates the v8 update guide, as the `init` function is now asynchronous and needs to be wrapped in an async function (in CommonJS).

Couple of other changes I spotted:

* make `viewsPath` an array so that it’s easier and more obvious how to add additional paths
* add 'app/assets/javascript/*.js' to `entryPoints` so that any javascript files are built by default