### PR TITLE
Update v8 upgrade guide

### DIFF
--- a/app/install/updating-to-version-8.md
+++ b/app/install/updating-to-version-8.md
@@ -134,7 +134,7 @@ async function init() {
   const prototype = await NHSPrototypeKit.init({
     serviceName: config.serviceName,
     buildOptions: {
-      entryPoints: entryPoints
+      entryPoints
     },
     viewsPath,
     routes,


### PR DESCRIPTION
This updates the v8 upgrade guide with some last minute changes:

* `filters` can now be passed into the `NHSPrototypeKit.init({` function
* `port` is now specified on the `prototype.start()` function again