### PR TITLE
Remove remaining download link

### DIFF
--- a/app/guides/switching-from-govuk-prototype-kit.md
+++ b/app/guides/switching-from-govuk-prototype-kit.md
@@ -14,8 +14,8 @@ When you are installing and running your prototype:
 
 {% list title="Do", type="tick" %}
 
-- get the kit either by [downloading it as a zip]({{downloadUrl}}) or by [cloning or downloading a copy from GitHub](https://github.com/nhsuk/nhsuk-prototype-kit)
-- start your local server by running `npm run watch`
+- get the kit by [creating a new prototype](/install/creating-a-new-prototype/) using the GitHub template
+- start your local server by running `npm start`
   {%- endlist %}
 
 {% list title="Don’t", type="cross" %}

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -75,12 +75,6 @@ export default function (eleventyConfig) {
       'https://prototype-kit.service-manual.nhs.uk'
   })
 
-  // Add global data
-  eleventyConfig.addGlobalData(
-    'downloadUrl',
-    `https://github.com/nhsuk/nhsuk-prototype-kit/archive/refs/tags/v7.1.0.zip`
-  )
-
   // Passthrough
   eleventyConfig.addPassthroughCopy('./app/assets/images')
 


### PR DESCRIPTION
Didn't spot this in the "switching from GOV.UK" guide!