### PR TITLE
Add 'Copy code' buttons

### DIFF
--- a/app/guides/branching.md
+++ b/app/guides/branching.md
@@ -12,7 +12,7 @@ To do this, add some JavaScript to your `routes.js` file.
 
 Send users to different pages based on their radio button selection:
 
-```js
+```js { .nhsuk-code--button }
 router.post('/appointment-type-answer', function (req, res) {
   const data = req.session.data
   const appointmentType = data.appointmentType
@@ -48,7 +48,7 @@ To test if any of of several checkboxes have been checked, combine several of th
 
 To test if multiple checkboxes have all been checked, combine several of these with `&&`, which means 'and'.
 
-```js
+```js { .nhsuk-code--button }
 router.post('/symptoms-answer', function (req, res) {
   const data = req.session.data
   const symptoms = data.symptoms || []
@@ -93,7 +93,7 @@ You can then use these operators to test the number:
 - `<` – less than
 - `<=` – less than or equal to
 
-```js
+```js { .nhsuk-code--button }
 router.post('/days-experiencing-symptoms-answer', function (req, res) {
   const data = req.session.data
 

--- a/app/guides/build-basic-prototype/branching.md
+++ b/app/guides/build-basic-prototype/branching.md
@@ -15,7 +15,7 @@ We'll make a route that takes the answer the user gave to the 1st question and e
 
 First, make an `{{example.ineligible.url}}.html` page by copying this code to `app/views`.
 
-```njk
+```njk { .nhsuk-code--button }
 {% raw %}{% extends "layout.html" %}
 
 {% set pageName = "Ineligible" %}
@@ -43,7 +43,7 @@ Currently, the `{{example.radios.url}}` page sends the user directly to question
 2. Open `/app/routes.js`.
 3. Insert new JavaScript into line 5, before `module.exports = router`.
 
-   ```js
+   ```js { .nhsuk-code--button }
    // Run this code when a form submitted to '/{{example.radios.url}}-answer'
    router.post('/{{example.radios.url}}-answer', function (req, res) {
 

--- a/app/guides/build-basic-prototype/create-pages.md
+++ b/app/guides/build-basic-prototype/create-pages.md
@@ -11,7 +11,7 @@ Create an empty file named <kbd>{{example.startPage.url}}.html</kbd> in your `ap
 
 Add this line to the very top of your file:
 
-```njk
+```njk { .nhsuk-code--button }
 {% raw %}{% extends "layout.html" %}{% endraw %}
 ```
 
@@ -46,7 +46,7 @@ Create 2 empty files for question pages in `app/views` named:
 
 As before, add this line to the top of each file:
 
-```njk
+```njk { .nhsuk-code--button }
 {% raw %}{% extends "layout.html" %}{% endraw %}
 ```
 
@@ -66,7 +66,7 @@ Create an empty file named <kbd>{{example.checkAnswers.url}}.html</kbd> in `app/
 
 Add this line to the top of the file:
 
-```njk
+```njk { .nhsuk-code--button }
 {% raw %}{% extends "layout.html" %}{% endraw %}
 ```
 
@@ -82,7 +82,7 @@ Copy the Nunjucks code from the [confirmation page pattern](https://service-manu
 
 Add this line to the top of the file:
 
-```njk
+```njk { .nhsuk-code--button }
 {% raw %}{% extends "layout.html" %}{% endraw %}
 ```
 

--- a/app/guides/build-basic-prototype/let-user-change-answers.md
+++ b/app/guides/build-basic-prototype/let-user-change-answers.md
@@ -20,7 +20,7 @@ Open the `{{example.radios.url}}.html` file in your `app/views` folder.
 
 Update the radios component to add `value: data.hasSymptoms,`, like this:
 
-```njk
+```njk { .nhsuk-code--button }
 {% raw %}{{ radios({
   idPrefix: "has-symptoms",
   name: "hasSymptoms",

--- a/app/guides/build-basic-prototype/show-users-answers.md
+++ b/app/guides/build-basic-prototype/show-users-answers.md
@@ -38,7 +38,7 @@ On the "Check answers" template page, there are example answers that you do not 
 
 Your code should now look like this:
 
-```njk
+```njk { .nhsuk-code--button }
 {% raw %}<div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-two-thirds">
     <h1 class="nhsuk-heading-l">

--- a/app/guides/build-basic-prototype/use-components-2.md
+++ b/app/guides/build-basic-prototype/use-components-2.md
@@ -20,7 +20,7 @@ Our `{{example.textarea.url}}.html` page is going to have a textarea component t
 
 Your component code should now look like this:
 
-```njk
+```njk { .nhsuk-code--button }
 {% raw %}{{ textarea({
   name: "details",
   id: "details",

--- a/app/guides/build-basic-prototype/use-components.md
+++ b/app/guides/build-basic-prototype/use-components.md
@@ -31,7 +31,7 @@ In the design system, components have both Nunjucks and HTML code examples. Eith
 
 Your component code should now look like this:
 
-```njk
+```njk { .nhsuk-code--button }
 {% raw %}{{ radios({
   idPrefix: "has-symptoms",
   name: "hasSymptoms",

--- a/app/guides/making-pages.md
+++ b/app/guides/making-pages.md
@@ -22,7 +22,7 @@ Each page you create will need to specify which layout it uses. Otherwise you’
 
 To use the standard layout that comes with the prototype kit, add this line to the top of each file:
 
-```njk
+```njk { .nhsuk-code--button }
 {% raw %}{% extends "layout.html" %}{% endraw %}
 ```
 


### PR DESCRIPTION
This adds a 'Copy code' button to some of the examples in the guidance and tutorial.

Fixes #350


| Before | After |
|--------|-------|
| <img width="817" height="851" alt="Screenshot 2026-04-07 at 14 55 03" src="https://github.com/user-attachments/assets/50c2985d-c7ec-4ce2-9285-3e5b91b311dd" /> | <img width="808" height="898" alt="Screenshot 2026-04-07 at 14 54 54" src="https://github.com/user-attachments/assets/6c1d8b21-0504-477c-9763-ea5f97652712" /> |
