### PR TITLE
Update note about nhsapp-frontend in update guide

### DIFF
--- a/app/install/updating-the-kit.md
+++ b/app/install/updating-the-kit.md
@@ -35,7 +35,7 @@ In the `dependencies` section, update the contents to:
 
 > [!NOTE]
 > If you are also using the [NHS App design system](https://design-system.nhsapp.service.nhs.uk), keep
-> `nhsapp-frontend` within your `dependencies` section too.
+> `nhsapp-frontend` within your `dependencies` section too. You may need to update it to the latest version.
 
 In the `devDependencies` section, update the contents to:
 


### PR DESCRIPTION
One user got stuck when following the guide as they were using version 4 of `nhsapp-frontend` which had conflicting dependency requirements for `nhsuk-frontend` (needs to be on version 5+).