### PR TITLE
Remove step numbers from tutorial

### DIFF
--- a/app/guides/build-basic-prototype/build-basic-prototype.json
+++ b/app/guides/build-basic-prototype/build-basic-prototype.json
@@ -1,6 +1,6 @@
 {
   "eleventyComputed": {
-    "caption": "Step {{order}} of 8: Build a basic prototype",
+    "caption": "Build a basic prototype",
     "eleventyNavigation": {
       "key": "{{caption}} – {{title}}",
       "parent": "Build a basic prototype"


### PR DESCRIPTION
Not sure these are that helpful, and they're currently wrong, showing "Step 9 of 8".

Removing them makes the caption (shown above the h1) shorter and more consistent.

Fixes #463
