### PR TITLE
Improve start page of the tutorial

### DIFF
--- a/app/guides/build-basic-prototype.md
+++ b/app/guides/build-basic-prototype.md
@@ -1,5 +1,4 @@
 ---
-caption: Tutorial
 title: Build a basic prototype
 description: This tutorial will show you how to prototype a fictional service.
 order: 1
@@ -10,19 +9,27 @@ tags:
 Our fictional 'Order a test to check if you have magical powers' service will:
 
 - ask 2 questions
-- show the user's answers for them to check
+- take users to different pages depending on their answers
+- summarise the user's answers for them to check
 - show a confirmation page
 
-It will take about an hour to finish this tutorial, after you install the prototype kit.
+It will take about an hour to complete this tutorial.
 
-Our prototype will look a bit like this:
+This diagram shows how the pages will link together:
 
 ![The first page has the title 'Start page' with the button 'Start now'. This is linked to a 2nd page with the title 'Question 1' and a 'Continue' button. This forks to 2 different pages. The first is titled 'Ineligible' and the second is titled 'Question 2'. Question 2 is linked to a page titled 'Check answers'. This links to page 6, titled 'Complete'.](/assets/images/guides/build-basic-prototype/overview.png 'Diagram of 6 pages connected together')
 
 ## Before you start
 
-Before you start, you must [install](/install) and run the NHS prototype kit.
+Before you start, you must first [create a new prototype](/install/creating-a-new-prototype/) using the GitHub template.
 
-You'll also need a code editor. Any HTML text editor will do, but we recommend [Visual Studio Code](https://code.visualstudio.com) (also known as VS Code). This is because it is free and has lots of useful features.
+You’ll then need to either:
+
+* install the kit on your computer
+* run the kit in the cloud
+
+See [get started](/install/) for guidance on both options.
+
+Once you’ve done this, you’re ready to start the tutorial.
 
 {% actionLink text="Start tutorial", href="/guides/build-basic-prototype/open-prototype-in-editor" %}

--- a/app/guides/build-basic-prototype.md
+++ b/app/guides/build-basic-prototype.md
@@ -25,8 +25,8 @@ Before you start, you must first [create a new prototype](/install/creating-a-ne
 
 You’ll then need to either:
 
-* install the kit on your computer
-* run the kit in the cloud
+- install the kit on your computer
+- run the kit in the cloud
 
 See [get started](/install/) for guidance on both options.
 


### PR DESCRIPTION
This aims to make it clearer that you first need to create a new prototype using the GitHub template (see first link), and then need to either install it locally, or follow the guidance to run it in the cloud using Codespaces.

Only after this should users start the tutorial.

The intro now more-or-less follows the spiel from the in-person prototype kit training.