### PR TITLE
Use nested <kbd> to represent keyboard keys to press

### DIFF
--- a/app/assets/application.scss
+++ b/app/assets/application.scss
@@ -19,29 +19,4 @@
   .nhsuk-image__img {
     padding: nhsuk-spacing(2);
   }
-
-  samp {
-    font-family: $nhsuk-font, $nhsuk-font-fallback;
-    word-break: keep-all;
-  }
-
-  code.app-code--inline,
-  kbd {
-    font-family: ui-monospace, monospace;
-    font-weight: normal;
-  }
-
-  code.app-code--inline,
-  kbd:not(:has(> kbd)),
-  samp {
-    background-color: nhsuk-colour("white");
-    border-radius: $nhsuk-border-radius;
-    font-size: 1em;
-    padding: 0.15rem 0.3rem;
-  }
-
-  kbd samp {
-    font-weight: 600;
-    padding: 0;
-  }
 }

--- a/app/guides/build-basic-prototype/create-pages.md
+++ b/app/guides/build-basic-prototype/create-pages.md
@@ -31,7 +31,7 @@ You'll normally edit the HTML to make changes to pages, but the service name is 
 
 1. Open the `config.js` file in your `app` folder
 2. Change `serviceName` from `"Service name goes here"` to `"{{example.name}}"`
-3. Press <kbd>Cmd</kbd> + <kbd>S</kbd> on Mac or <kbd>Ctrl</kbd> + <kbd>S</kbd> on Windows to save your change
+3. Press <kbd><kbd>Command</kbd></kbd> + <kbd><kbd>S</kbd></kbd> on Mac or <kbd><kbd>Ctrl</kbd></kbd> + <kbd><kbd>S</kbd></kbd> on Windows to save your change
 
 You must save every time you make a change to a file. In most code editors, a dot appears in the tab for any file that has unsaved changes.
 

--- a/app/guides/git.md
+++ b/app/guides/git.md
@@ -14,7 +14,7 @@ If you want to use GitHub Desktop, go to our guide for [using GitHub and GitHub 
 
 ## 1. Check if you have Git installed
 
-Open a terminal, type <kbd>git --version</kbd> and press enter.
+Open a terminal, type <kbd>git --version</kbd> and press <kbd><kbd>Enter</kbd></kbd>.
 
 If git is installed, you will see the version installed, something similar to this:
 

--- a/app/install/windows/terminal.md
+++ b/app/install/windows/terminal.md
@@ -9,7 +9,7 @@ You'll use the Command Prompt to install, start and stop the kit.
 To open the Command Prompt:
 
 - Click Start
-- In the Search, type <kbd>cmd</kbd> (short for command) or <kbd>commandprompt</kbd>, and press Enter.
+- In the Search, type <kbd>cmd</kbd> (short for command) or <kbd>commandprompt</kbd>, and press <kbd><kbd>Enter</kbd></kbd>.
 
 When you open the application, it will contain text similar to this:
 


### PR DESCRIPTION
From the HTML specs:

> When the kbd element is nested inside another kbd element, it represents an actual key or other single unit of input as appropriate for the input mechanism.

https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-kbd-element

CSS for this is now included upstream in NHS Frontend at https://github.com/nhsuk/nhsuk-frontend/blob/077a694b06dcc18e285ce4ed2f2673589066b6f4/packages/nhsuk-frontend/src/nhsuk/core/styles/_typography.scss#L305-L334 so we can remove our custom styles for these.

Also using "Command" instead of "Cmd" as Apple keyboards now seem to spell it out in full (but Windows keyboards don't).

## Screenshot

| Before | After |
| -----  | ----- |
| <img width="823" height="529" alt="Screenshot 2026-06-05 at 12 09 38" src="https://github.com/user-attachments/assets/a3007986-9385-4e1e-9476-0b7452c8e3b6" /> |  <img width="819" height="518" alt="Screenshot 2026-06-05 at 12 10 00" src="https://github.com/user-attachments/assets/19adce4b-ba7e-49f8-b626-6272702bfbc9" /> |
