### PR TITLE
Add redirect from /install/simple

### DIFF
--- a/app/install.md
+++ b/app/install.md
@@ -14,6 +14,8 @@ groups:
     items: collections.install-cloud
     clickable: true
     columns: 3
+redirectFrom:
+  - /install/simple/
 ---
 
 Before you start using the kit, you'll need some basic knowledge of HTML. You can learn this at [MDN](https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/Getting_started), [Codecademy](https://www.codecademy.com/learn/learn-html-fundamentals) or other tutorial websites.


### PR DESCRIPTION
This page was renamed in https://github.com/nhsuk/nhsuk.service-manual.prototype-kit.docs/pull/353 but we didn't add a redirect.

However, https://design-system.nhsapp.service.nhs.uk/get-started/nhsapp-prototype/setup/ links to that page, opps.

(Fixing that link separately in https://github.com/nhsuk/nhsapp-frontend/pull/479)